### PR TITLE
Support selecting a pdf version for the output

### DIFF
--- a/cmd/pdfcpu/main.go
+++ b/cmd/pdfcpu/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-
 	"os"
 	"strings"
 
@@ -33,6 +32,7 @@ import (
 var (
 	fileStats, mode, pageSelection string
 	upw, opw, key, perm            string
+	pdfVersion                     string
 	verbose                        bool
 
 	needStackTrace = true
@@ -55,6 +55,10 @@ func init() {
 	permUsage := "encrypt, perm set: none|all"
 	flag.StringVar(&perm, "perm", "none", permUsage)
 
+	pdfVersionUsage := "pdfVersion: 1.7|1.6|1.5|1.4|1.3|1.2|1.1|1.0"
+	flag.StringVar(&pdfVersion, "pdfVersion", "1.7", pdfVersionUsage)
+	flag.StringVar(&pdfVersion, "pv", "1.7", pdfVersionUsage)
+
 	pageSelectionUsage := "a comma separated list of pages or page ranges, see pdfcpu help split/extract"
 	flag.StringVar(&pageSelection, "pages", "", pageSelectionUsage)
 	flag.StringVar(&pageSelection, "p", "", pageSelectionUsage)
@@ -76,6 +80,8 @@ func main() {
 	config := pdfcpu.NewDefaultConfiguration()
 	config.UserPW = upw
 	config.OwnerPW = opw
+	v, _ := pdfcpu.PDFVersion(pdfVersion)
+	config.Version = v
 
 	var cmd *api.Command
 

--- a/pkg/pdfcpu/configuration.go
+++ b/pkg/pdfcpu/configuration.go
@@ -117,6 +117,9 @@ type Configuration struct {
 
 	// Command being executed.
 	Mode CommandMode
+
+	// PDF Version
+	Version Version
 }
 
 // NewDefaultConfiguration returns the default pdfcpu configuration.
@@ -133,6 +136,7 @@ func NewDefaultConfiguration() *Configuration {
 		EncryptUsingAES:       true,
 		EncryptUsing128BitKey: true,
 		UserAccessPermissions: PermissionsNone,
+		Version:               V17,
 	}
 }
 

--- a/pkg/pdfcpu/write.go
+++ b/pkg/pdfcpu/write.go
@@ -75,7 +75,7 @@ func WritePDFFile(ctx *Context) error {
 
 	// Since we support PDF Collections (since V1.7) for file attachments
 	// we need to always generate V1.7 PDF filess.
-	err = writeHeader(ctx.Write, V17)
+	err = writeHeader(ctx.Write, ctx.Configuration.Version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I needed to trim PDFs with specific version requirements on write. Not sure if it has a place in master but here is the PR.

Regardless, I would be grateful if you could review whether this is all it is needed to generate PDFs with specific versions or not. @hhrutter 