### PR TITLE
Make LastModified optional rather than required in validatePieceDict

### DIFF
--- a/pkg/pdfcpu/validate/xReftable.go
+++ b/pkg/pdfcpu/validate/xReftable.go
@@ -526,7 +526,11 @@ func validatePieceDict(xRefTable *pdf.XRefTable, d pdf.Dict) error {
 			continue
 		}
 
-		_, err = validateDateEntry(xRefTable, d1, dictName, "LastModified", OPTIONAL, pdf.V10)
+		required := REQUIRED
+		if xRefTable.ValidationMode == pdf.ValidationRelaxed {
+			required = OPTIONAL
+		}
+		_, err = validateDateEntry(xRefTable, d1, dictName, "LastModified", required, pdf.V10)
 		if err != nil {
 			return err
 		}

--- a/pkg/pdfcpu/validate/xReftable.go
+++ b/pkg/pdfcpu/validate/xReftable.go
@@ -526,7 +526,7 @@ func validatePieceDict(xRefTable *pdf.XRefTable, d pdf.Dict) error {
 			continue
 		}
 
-		_, err = validateDateEntry(xRefTable, d1, dictName, "LastModified", REQUIRED, pdf.V10)
+		_, err = validateDateEntry(xRefTable, d1, dictName, "LastModified", OPTIONAL, pdf.V10)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Many PDFs I've run across lately fail to load due to this being required
and changing it to optional allows them to load fine. LastModified does
not seem to be essential and allowing it to be optional should not be
harmful in any way.