### PR TITLE
Introduce function PageCountFile

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -40,7 +40,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("%v", err)
 		os.Exit(1)
 	}
-	//fmt.Printf("outDir = %s\n", outDir)
+	// fmt.Printf("outDir = %s\n", outDir)
 
 	exitCode := m.Run()
 
@@ -105,6 +105,25 @@ func AllPDFs(t *testing.T, dir string) []string {
 	}
 	return ff
 }
+
+func TestPageCount(t *testing.T) {
+	msg := "TestPageCount"
+
+	fn := "5116.DCT_Filter.pdf"
+	wantPageCount := 52
+	inFile := filepath.Join(inDir, fn)
+
+	// Retrieve page count for inFile.
+	gotPageCount, err := PageCountFile(inFile)
+	if err != nil {
+		t.Fatalf("%s: %v\n", msg, err)
+	}
+
+	if wantPageCount != gotPageCount {
+		t.Fatalf("%s %s: pageCount want:%d got:%d\n", msg, inFile, wantPageCount, gotPageCount)
+	}
+}
+
 func TestPageDimensions(t *testing.T) {
 	msg := "TestPageDimensions"
 	for _, fn := range AllPDFs(t, inDir) {
@@ -215,7 +234,7 @@ func TestInsertRemovePages(t *testing.T) {
 	inFile := filepath.Join(inDir, "Acroforms2.pdf")
 	outFile := filepath.Join(outDir, "test.pdf")
 
-	n1, err := PageCount(inFile)
+	n1, err := PageCountFile(inFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}
@@ -227,7 +246,7 @@ func TestInsertRemovePages(t *testing.T) {
 	if err := ValidateFile(outFile, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	n2, err := PageCount(outFile)
+	n2, err := PageCountFile(outFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, outFile, err)
 	}
@@ -242,7 +261,7 @@ func TestInsertRemovePages(t *testing.T) {
 	if err := ValidateFile(outFile, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	n2, err = PageCount(outFile)
+	n2, err = PageCountFile(outFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -531,7 +531,7 @@ func TestGetPageCount(t *testing.T) {
 	msg := "TestInsertRemovePages"
 	inFile := filepath.Join(inDir, "CenterOfWhy.pdf")
 
-	n, err := api.PageCount(inFile)
+	n, err := api.PageCountFile(inFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}
@@ -545,7 +545,7 @@ func TestInsertRemovePages(t *testing.T) {
 	inFile := filepath.Join(inDir, "Acroforms2.pdf")
 	outFile := filepath.Join(outDir, "test.pdf")
 
-	n1, err := api.PageCount(inFile)
+	n1, err := api.PageCountFile(inFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}
@@ -557,7 +557,7 @@ func TestInsertRemovePages(t *testing.T) {
 	if err := validateFile(t, outFile, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	n2, err := api.PageCount(outFile)
+	n2, err := api.PageCountFile(outFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}
@@ -572,7 +572,7 @@ func TestInsertRemovePages(t *testing.T) {
 	if err := validateFile(t, outFile, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	n2, err = api.PageCount(outFile)
+	n2, err = api.PageCountFile(outFile)
 	if err != nil {
 		t.Fatalf("%s %s: %v\n", msg, inFile, err)
 	}


### PR DESCRIPTION
Hi!
First of all, I really like the idea of the project you are building here, and thank you for doing that!

We, at [Ingrid](ingrid.com), use this package to merge PDFs and we need to check if the number of pages in tests.

This PR introduces function `PageCountFile` which counts pages in `inFile`. Also function `PageCount` now expects `io.ReadSeeker`.

It requires to call `validate.XRefTable` inside `api.PageCount`. I tried to put this into `api.ReadContext` but then test `cli.TestOptimize` failed with case when `ValidationMode` was set to `pdf.ValidationNone` and I'm not able to fix this. Maybe you can help.