### PR TITLE
Fix Color Lookup for Flat encoded image

### DIFF
--- a/pkg/pdfcpu/imageWrite.go
+++ b/pkg/pdfcpu/imageWrite.go
@@ -125,7 +125,7 @@ func colorLookupTable(xRefTable *XRefTable, o Object) ([]byte, error) {
 	switch o := o.(type) {
 
 	case StringLiteral:
-		lookup = []byte(o.String())
+		return Unescape(string(o))
 
 	case HexLiteral:
 		lookup, err = o.Bytes()

--- a/pkg/pdfcpu/string.go
+++ b/pkg/pdfcpu/string.go
@@ -18,23 +18,16 @@ package pdfcpu
 
 import (
 	"bytes"
-	"math"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 )
 
 // Convert a 1,2 or 3 digit unescaped octal string into the corresponding byte value.
-func byteForOctalString(octalBytes []byte) (b byte) {
-
-	var j float64
-
-	for i := len(octalBytes) - 1; i >= 0; i-- {
-		b += (octalBytes[i] - '0') * byte(math.Pow(8, j))
-		j++
-	}
-
-	return
+func byteForOctalString(octalBytes string) (b byte) {
+	i, _ := strconv.ParseInt(octalBytes, 8, 64)
+	return byte(i)
 }
 
 // Escape applies all defined escape sequences to s.
@@ -102,7 +95,7 @@ func Unescape(s string) ([]byte, error) {
 
 	var esc bool
 	var longEol bool
-	var octalCode []byte
+	var octalCode string
 	var b bytes.Buffer
 
 	for i := 0; i < len(s); i++ {
@@ -142,10 +135,10 @@ func Unescape(s string) ([]byte, error) {
 			if !strings.ContainsRune("01234567", rune(c)) {
 				return nil, errors.Errorf("Unescape: illegal octal sequence detected %X", octalCode)
 			}
-			octalCode = append(octalCode, c)
+			octalCode = octalCode + string(c)
 			if len(octalCode) == 3 {
 				b.WriteByte(byteForOctalString(octalCode))
-				octalCode = nil
+				octalCode = ""
 				esc = false
 			}
 			continue
@@ -169,7 +162,7 @@ func Unescape(s string) ([]byte, error) {
 		var octal bool
 		octal, c = escaped(c)
 		if octal {
-			octalCode = append(octalCode, c)
+			octalCode = octalCode + string(c)
 			continue
 		}
 

--- a/pkg/pdfcpu/string_test.go
+++ b/pkg/pdfcpu/string_test.go
@@ -1,0 +1,49 @@
+package pdfcpu
+
+import (
+	"testing"
+)
+
+func TestByteForOctalString(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected byte
+	}{
+		{
+			"001",
+			0x1,
+		},
+		{
+			"01",
+			0x1,
+		},
+		{
+			"1",
+			0x1,
+		},
+		{
+			"010",
+			0x8,
+		},
+		{
+			"020",
+			0x10,
+		},
+		{
+			"030",
+			0x18,
+		},
+		{
+			"377",
+			0xff,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			actual := byteForOctalString(test.input)
+			if actual != test.expected {
+				t.Errorf("got %x; want %x", test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix Images extraction bug for documents with Flat Encoded Image and Indexed CS.

1. For Lookup Colors Unescape String Literal. Currently we only convert sting to bytes.
2. Unescape String - fix Octal String encoding.