### PR TITLE
Fix crash found with go-fuzz

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -76,14 +76,18 @@ func NewFilter(filterName string, parms map[string]int) (filter Filter, err erro
 
 	case CCITTFax:
 		filter = ccittDecode{baseFilter{parms}}
-
-	// DCT
-	// JBIG2
-	// JPX
-
-	default:
+	case DCT:
+		// Unsupported
+		fallthrough
+	case JBIG2:
+		// Unsupported
+		fallthrough
+	case JPX:
+		// Unsupported
 		log.Info.Printf("Filter not supported: <%s>", filterName)
 		err = ErrUnsupportedFilter
+	default:
+		err = errors.Errorf("Invalid filter: <%s>", filterName)
 	}
 
 	return filter, err

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -19,6 +19,7 @@ package filter_test
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -68,6 +69,31 @@ func encodeDecodeUsingFilterNamed(t *testing.T, filterName string) {
 		t.Fatal("original content != decoded content")
 	}
 
+}
+
+func TestFilterSupport(t *testing.T) {
+	var filtersTests = []struct {
+		filterName string
+		expected   error
+	}{
+		{filter.ASCII85, nil},
+		{filter.ASCIIHex, nil},
+		{filter.RunLength, nil},
+		{filter.LZW, nil},
+		{filter.Flate, nil},
+		{filter.CCITTFax, nil},
+		{filter.DCT, filter.ErrUnsupportedFilter},
+		{filter.JBIG2, filter.ErrUnsupportedFilter},
+		{filter.JPX, filter.ErrUnsupportedFilter},
+		{"INVALID_FILTER", errors.New("Invalid filter: <INVALID_FILTER>")},
+	}
+	for _, tt := range filtersTests {
+		_, err := filter.NewFilter(tt.filterName, nil)
+		if (tt.expected != nil && err != nil && err.Error() != tt.expected.Error()) ||
+			((err == nil || tt.expected == nil) && err != tt.expected) {
+			t.Errorf("Problem: '%s' (expected '%s')\n", err.Error(), tt.expected.Error())
+		}
+	}
 }
 
 func TestEncodeDecode(t *testing.T) {


### PR DESCRIPTION
When i was testing go-fuzz, i found some crash on `pdfcpu.parseObjectStream` with this code:
```go
//+build: go-fuzz
package pdfcpu

import (
        "bytes"
        pdf "github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
)

func Fuzz(data []byte) int {
    if _, err := pdf.Read(bytes.NewReader(data), pdf.NewDefaultConfiguration()); err != nil {
      return 0
    }
    return 1
}
```

You can reproduce it with:
```go
package main

import (
        "os"
        pdf "github.com/pdfcpu/pdfcpu/pkg/pdfcpu" 
)

func main() {
        f, _ := os.Open("crash-18673daced3f9579540897da71f8c9437ae87f44")
        defer f.Close()

        pdf.Read(f, pdf.NewDefaultConfiguration())
}
```

[crash-18673daced3f9579540897da71f8c9437ae87f44.zip](https://github.com/pdfcpu/pdfcpu/files/3853494/crash-18673daced3f9579540897da71f8c9437ae87f44.zip)
