### PR TITLE
Add Dockerfile and usage instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile References: https://docs.docker.com/engine/reference/builder/
+
+# Start from the latest golang base image
+FROM golang:latest as builder
+
+# install
+RUN go get github.com/pdfcpu/pdfcpu/cmd/...
+WORKDIR $GOPATH/src/github.com/pdfcpu/pdfcpu/cmd/pdfcpu
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o pdfcpu .
+
+######## Start a new stage from scratch #######
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /go/src/github.com/pdfcpu/pdfcpu/cmd/pdfcpu .
+
+# Command to run the executable
+CMD ["./pdfcpu"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ However, to avoid confusion, we strongly recommend updating any existing local c
 git remote set-url origin https://github.com/pdfcpu/pdfcpu
 ```
 
+### Using Docker
+
+```
+docker build -t pdfcpu .
+# mount current folder into container to process local files
+docker run -it --mount type=bind,source="$(pwd)",target=/app pdfcpu ./pdfcpu validate -mode strict /app/pdfs/a.pdf
+```
 
 ## Contributing
 


### PR DESCRIPTION
So I wanted to experiment with pdfcpu without a local Go development environment.

This adds a simple multi-stage Dockerfile to build the binary and run from a scratch container.

```
% docker build -t pdfcpu .

% docker image ls
pdfcpu                       latest              bcaef81bbc0c        2 days ago          13.3MB

% docker run -it pdfcpu
pdfcpu is a tool for PDF manipulation written in Go.

Usage:

   pdfcpu command [arguments]
```