### PR TITLE
Fixed a bug in paperSize.go toMillimetres, which was returning d.Heig…

### DIFF
--- a/pkg/pdfcpu/paperSize.go
+++ b/pkg/pdfcpu/paperSize.go
@@ -56,7 +56,7 @@ func (d Dim) ToCentimetres() Dim {
 
 // ToMillimetres converts d to centimetres.
 func (d Dim) ToMillimetres() Dim {
-	return Dim{d.Height * userSpaceToMm, d.Height * userSpaceToMm}
+	return Dim{d.Width * userSpaceToMm, d.Height * userSpaceToMm}
 }
 
 // AspectRatio returns the relation between width and height.

--- a/pkg/pdfcpu/paperSize.go
+++ b/pkg/pdfcpu/paperSize.go
@@ -49,14 +49,14 @@ func (d Dim) ToInches() Dim {
 	return Dim{d.Width * userSpaceToInch, d.Height * userSpaceToInch}
 }
 
-// ToCentimeters converts d to centimetres.
-func (d Dim) ToCentimeters() Dim {
+// ToCentimetres converts d to centimetres.
+func (d Dim) ToCentimetres() Dim {
 	return Dim{d.Width * userSpaceToCm, d.Height * userSpaceToCm}
 }
 
-// ToMillimeters converts d to centimetres.
-func (d Dim) ToMillimeters() Dim {
-	return Dim{d.Width * userSpaceToMm, d.Height * userSpaceToMm}
+// ToMillimetres converts d to centimetres.
+func (d Dim) ToMillimetres() Dim {
+	return Dim{d.Height * userSpaceToMm, d.Height * userSpaceToMm}
 }
 
 // AspectRatio returns the relation between width and height.

--- a/pkg/pdfcpu/paperSize.go
+++ b/pkg/pdfcpu/paperSize.go
@@ -49,14 +49,14 @@ func (d Dim) ToInches() Dim {
 	return Dim{d.Width * userSpaceToInch, d.Height * userSpaceToInch}
 }
 
-// ToCentimetres converts d to centimetres.
-func (d Dim) ToCentimetres() Dim {
+// ToCentimeters converts d to centimetres.
+func (d Dim) ToCentimeters() Dim {
 	return Dim{d.Width * userSpaceToCm, d.Height * userSpaceToCm}
 }
 
-// ToMillimetres converts d to centimetres.
-func (d Dim) ToMillimetres() Dim {
-	return Dim{d.Height * userSpaceToMm, d.Height * userSpaceToMm}
+// ToMillimeters converts d to centimetres.
+func (d Dim) ToMillimeters() Dim {
+	return Dim{d.Width * userSpaceToMm, d.Height * userSpaceToMm}
 }
 
 // AspectRatio returns the relation between width and height.


### PR DESCRIPTION
…ht twice instead of d.Width and d.Height; and fixed ToMillimeters and ToCentimeters spelling errors.