### PR TITLE
Fix test that was comparing the same variable.

### DIFF
--- a/pkg/pdfcpu/image_test.go
+++ b/pkg/pdfcpu/image_test.go
@@ -138,7 +138,7 @@ func compare(t *testing.T, fn1, fn2 string) {
 		return
 	}
 
-	if len(bb1) != len(bb1) {
+	if len(bb1) != len(bb2) {
 		t.Errorf("%s <-> %s: length mismatch %d != %d", fn1, fn2, len(bb1), len(bb2))
 		return
 	}


### PR DESCRIPTION
Hey there!
I was [scanning a bunch of Go code](https://semgrep.live/scan/106a6a66-c996-4b1d-8cd0-1102f1ed4b26) and found this issue.
It looks like this test case in `pkg/pdfcpu/image_test.go` was intending to compare `bb1` with `bb2`, but it was comparing `bb1` twice.
Anyway, I hope this helps!