### PR TITLE
Handle non *os.File buffers. (Fix #207)

### DIFF
--- a/pkg/pdfcpu/context.go
+++ b/pkg/pdfcpu/context.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -719,7 +720,7 @@ type WriteContext struct {
 
 	// The PDF-File which gets generated.
 	*bufio.Writer                     // A writer associated with Fp.
-	Fp                  io.Writer     // A file pointer needed for detecting FileSize.
+	Fp                  *os.File      // A file pointer needed for detecting FileSize.
 	FileSize            int64         // The size of the written file.
 	DirName             string        // The output directory.
 	FileName            string        // The output file name.

--- a/pkg/pdfcpu/write.go
+++ b/pkg/pdfcpu/write.go
@@ -31,9 +31,7 @@ import (
 )
 
 // Write generates a PDF file for the cross reference table contained in Context.
-func Write(ctx *Context) error {
-	var err error
-
+func Write(ctx *Context) (err error) {
 	// Create a writer for dirname and filename if not already supplied.
 	if ctx.Write.Writer == nil {
 

--- a/pkg/pdfcpu/write.go
+++ b/pkg/pdfcpu/write.go
@@ -32,8 +32,6 @@ import (
 
 // Write generates a PDF file for the cross reference table contained in Context.
 func Write(ctx *Context) error {
-
-	var file *os.File
 	var err error
 
 	// Create a writer for dirname and filename if not already supplied.
@@ -42,12 +40,13 @@ func Write(ctx *Context) error {
 		fileName := filepath.Join(ctx.Write.DirName, ctx.Write.FileName)
 		log.CLI.Printf("writing to %s\n", fileName)
 
-		file, err = os.Create(fileName)
+		file, err := os.Create(fileName)
 		if err != nil {
 			return errors.Wrapf(err, "can't create %s\n%s", fileName, err)
 		}
 
 		ctx.Write.Writer = bufio.NewWriter(file)
+		ctx.Write.Fp = file
 
 		defer func() {
 
@@ -127,7 +126,7 @@ func Write(ctx *Context) error {
 		return err
 	}
 
-	err = setFileSizeOfWrittenFile(ctx.Write, file)
+	err = setFileSizeOfWrittenFile(ctx.Write)
 	if err != nil {
 		return err
 	}
@@ -1017,24 +1016,18 @@ func writeXRef(ctx *Context) error {
 	return writeXRefTable(ctx)
 }
 
-func setFileSizeOfWrittenFile(w *WriteContext, f *os.File) error {
-
+func setFileSizeOfWrittenFile(w *WriteContext) error {
 	err := w.Flush()
 	if err != nil {
 		return err
 	}
 
-	f1 := f
-
 	// If writing is Writer based then f is nil.
-	if f == nil {
-		var ok bool
-		if f1, ok = w.Fp.(*os.File); !ok {
-			return errors.New("pdfcpu: missing write file descriptor")
-		}
+	if w.Fp == nil {
+		return nil
 	}
 
-	fileInfo, err := f1.Stat()
+	fileInfo, err := w.Fp.Stat()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related to https://github.com/pdfcpu/pdfcpu/issues/207.