### PR TITLE
fix missing reader size

### DIFF
--- a/pkg/pdfcpu/context.go
+++ b/pkg/pdfcpu/context.go
@@ -355,13 +355,11 @@ func newReadContext(rs io.ReadSeeker) (*ReadContext, error) {
 		XRefStreams:   IntSet{},
 	}
 
-	if f, ok := rs.(*os.File); ok {
-		fileInfo, err := f.Stat()
-		if err != nil {
-			return nil, err
-		}
-		rdCtx.FileSize = fileInfo.Size()
+	fileSize, err := rs.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, err
 	}
+	rdCtx.FileSize = fileSize
 
 	return rdCtx, nil
 }


### PR DESCRIPTION
Hi, 

[This commit](https://github.com/pdfcpu/pdfcpu/commit/0b3fcc7e006f3a096866183d3ca2c12a348202a3) introduce a new check in file pdfcpu/read.go, line 199: `offset >= ctx.Read.FileSize` 
The problem is that the quantity `ctx.Read.FileSize` is only set when the `io.ReadSeeker` is a `*os.File`.
In particular, it breaks the use of in-memory `ReadSeeker`s. 

Fortunately, we can retrieve the size of a general `ReadSeeker` by seeking to the end.