### PR TITLE
pdfpcu/filter: Do not read after EOD

### DIFF
--- a/pkg/filter/ascii85Decode.go
+++ b/pkg/filter/ascii85Decode.go
@@ -52,6 +52,10 @@ func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an ASCII85Decode filter.
 func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
+	// when possible, we make sure not to read passed EOD
+	if byteReader, ok := r.(io.ByteReader); ok {
+		r = newReacher(byteReader, []byte(eodASCII85))
+	}
 
 	p, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -66,11 +70,5 @@ func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
 	p = p[:len(p)-2]
 
 	decoder := ascii85.NewDecoder(bytes.NewReader(p))
-
-	buf, err := ioutil.ReadAll(decoder)
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes.NewBuffer(buf), nil
+	return decoder, nil
 }

--- a/pkg/filter/asciiHexDecode.go
+++ b/pkg/filter/asciiHexDecode.go
@@ -75,13 +75,5 @@ func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
 		p = append(p, '0')
 	}
 
-	// dst := make([]byte, hex.DecodedLen(len(p)))
-
 	return hex.NewDecoder(bytes.NewReader(p)), nil
-	// _, err = hex.Decode(dst, p)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return bytes.NewBuffer(dst), nil
 }

--- a/pkg/filter/asciiHexDecode.go
+++ b/pkg/filter/asciiHexDecode.go
@@ -48,6 +48,10 @@ func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
+	// when possible, we make sure not to read passed EOD
+	if byteReader, ok := r.(io.ByteReader); ok {
+		r = newReacher(byteReader, []byte{eodHexDecode})
+	}
 
 	bb, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -71,12 +75,13 @@ func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
 		p = append(p, '0')
 	}
 
-	dst := make([]byte, hex.DecodedLen(len(p)))
+	// dst := make([]byte, hex.DecodedLen(len(p)))
 
-	_, err = hex.Decode(dst, p)
-	if err != nil {
-		return nil, err
-	}
+	return hex.NewDecoder(bytes.NewReader(p)), nil
+	// _, err = hex.Decode(dst, p)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	return bytes.NewBuffer(dst), nil
+	// return bytes.NewBuffer(dst), nil
 }

--- a/pkg/filter/dct.go
+++ b/pkg/filter/dct.go
@@ -1,0 +1,121 @@
+package filter
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+// ByteReader allows both one byte and multi byte efficient
+// reads.
+type ByteReader interface {
+	io.Reader
+	io.ByteReader
+}
+
+// LimitedDCTDecoder return a Reader which do not read passed
+// the end of the image.
+// DCT is not among the supported decoders (since it would produce an Image)
+// but this function provides an alternative to parse inline image data.
+func LimitedDCTDecoder(input ByteReader) io.Reader {
+	return &jpegLimitedReader{source: input, scratch: &bytes.Buffer{}}
+}
+
+// implement a reader which don't read passed the EOD
+// we jump from markers to markers and save the data
+// into a temporary buffer
+// we follow the sketch described at
+// https://stackoverflow.com/questions/4585527/detect-eof-for-jpg-images
+type jpegLimitedReader struct {
+	source  ByteReader
+	scratch *bytes.Buffer // nil means EOD is reached
+}
+
+// read one byte from the source and stores it back to the buffer
+func (j jpegLimitedReader) read() (byte, error) {
+	c, err := j.source.ReadByte()
+	if err != nil {
+		return 0, unexpectedEOF(err)
+	}
+	j.scratch.WriteByte(c)
+	return c, nil
+}
+
+func (j *jpegLimitedReader) Read(p []byte) (int, error) {
+	if j.scratch == nil { // we have reached EOD
+		return 0, io.EOF
+	}
+
+	// if our internal buffer is large enough, just return the data
+	// and update the buffer
+	n := len(p)
+	if j.scratch.Len() >= n {
+		return j.scratch.Read(p)
+	}
+
+	// start reading from the source
+	c, err := j.read()
+	if err != nil {
+		return 0, err
+	}
+	for {
+		if c == 0xff { // start of a marker or fill bytes
+			next, err := j.read()
+			if err != nil {
+				return 0, err
+			}
+
+			if next == 0xD9 {
+				// end of data: return the remaining buffer
+				// and mark EOD by setting the buffer to nil
+				out, err := j.scratch.Read(p)
+				j.scratch = nil
+				return out, err
+			}
+
+			if next == 0xff {
+				// fill byte; we dont want to read another byte
+				// since `next` could be the start of a marker
+				c = next
+				continue
+			}
+
+			if next == 0 || next == 1 || (0xD0 <= next && next <= 0xD8) {
+				// standalone marker just, ignore it
+			} else {
+				lb1, err := j.read()
+				if err != nil {
+					return 0, err
+				}
+
+				lb2, err := j.read()
+				if err != nil {
+					return 0, err
+				}
+
+				segmentLength := int(uint16(lb2) | uint16(lb1)<<8)
+				// the length includes the two-byte length
+				if segmentLength < 2 {
+					return 0, errors.New("corrupted JPEG data")
+				}
+
+				// jump to the next segment and store the data
+				_, err = io.CopyN(j.scratch, j.source, int64(segmentLength-2))
+				if err != nil {
+					return 0, unexpectedEOF(err)
+				}
+			}
+		}
+
+		// if we now have enough bytes, return them ...
+		if j.scratch.Len() >= n {
+			return j.scratch.Read(p)
+		}
+
+		// ... else advance and loop
+		c, err = j.read()
+		if err != nil {
+			return 0, err
+		}
+	}
+}

--- a/pkg/filter/dct_test.go
+++ b/pkg/filter/dct_test.go
@@ -1,0 +1,59 @@
+package filter
+
+import (
+	"bytes"
+	"image"
+	"image/jpeg"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+)
+
+func randJPEG() ([]byte, error) {
+	var buf bytes.Buffer
+	img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+	for i := range img.Pix {
+		img.Pix[i] = uint8(rand.Int())
+	}
+	err := jpeg.Encode(&buf, img, nil)
+	return buf.Bytes(), err
+}
+
+func TestDCT(t *testing.T) {
+	for range [10]int{} {
+		b, err := randJPEG()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		additional := make([]byte, 250)
+		rand.Read(additional)
+
+		b = append(b, additional...)
+
+		rd := bytes.NewReader(b)
+		lim := LimitedDCTDecoder(rd)
+
+		_, err = jpeg.Decode(lim)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if rd.Len() != len(additional) {
+			t.Errorf("expected %d got %d", rd.Len(), len(additional))
+		}
+	}
+}
+
+func TestDCTFail(t *testing.T) {
+	for range [30]int{} {
+		input := make([]byte, 25000)
+		rand.Read(input)
+
+		lim := LimitedDCTDecoder(bytes.NewReader(input))
+		_, err := ioutil.ReadAll(lim)
+		if err == nil {
+			t.Error("expected error on random input data")
+		}
+	}
+}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -43,6 +43,10 @@ var ErrUnsupportedFilter = errors.New("pdfcpu: filter not supported")
 // Filter defines an interface for encoding/decoding PDF object streams.
 type Filter interface {
 	Encode(r io.Reader) (io.Reader, error)
+	// Decode decode the input `r`.
+	// If `r` also implements `io.ByteReader`, `Decode`
+	// does not read passed the end of the filtered data,
+	// making it possible to use it on longer data.
 	Decode(r io.Reader) (io.Reader, error)
 }
 

--- a/pkg/filter/reacher.go
+++ b/pkg/filter/reacher.go
@@ -1,0 +1,52 @@
+package filter
+
+import (
+	"bytes"
+	"io"
+)
+
+// only read until delim is reached (including delim)
+// so that the number of bytes read is a reliable way
+// to detect End Of Data of filtered content.
+type reacher struct {
+	source io.ByteReader
+	// the current matching bytes
+	// the invariant is that
+	// matched = delim[...:n] = (with n = length(matched))
+	// and matched are the last n bytes read (possibly 0)
+	matched []byte
+	delim   []byte // the target to find
+}
+
+// delim must not be empty
+func newReacher(source io.ByteReader, delim []byte) *reacher {
+	return &reacher{source: source, delim: delim, matched: make([]byte, 0, len(delim))}
+}
+
+func (r *reacher) Read(out []byte) (int, error) {
+	i := 0
+	for ; i < len(out); i++ {
+		// we have found the match, do no read anymore
+		if len(r.matched) == len(r.delim) {
+			return i, io.EOF
+		}
+
+		next, err := r.source.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+
+		// check for overlappings, starting with the biggest possible
+		r.matched = append(r.matched, next) // to avoid allocations
+		for j := 0; j <= len(r.matched); j++ {
+			if bytes.HasPrefix(r.delim, r.matched[j:]) {
+				r.matched = r.matched[j:]
+				break
+			}
+			// when i == len(r.matched) - 1 , HasPrefix is true
+			// and r.matched = []
+		}
+		out[i] = next
+	}
+	return i, nil
+}

--- a/pkg/filter/reacher_test.go
+++ b/pkg/filter/reacher_test.go
@@ -1,0 +1,78 @@
+package filter
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+)
+
+func TestReacher(t *testing.T) {
+	input := []byte("789456zesd45679998989")
+	rd := bytes.NewReader(input)
+	r := newReacher(rd, []byte("456"))
+	_, err := io.Copy(ioutil.Discard, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nbRead := len(input) - rd.Len()
+	if nbRead != 6 {
+		t.Error()
+	}
+
+	rd = bytes.NewReader(input)
+	r = newReacher(rd, []byte("998"))
+	_, err = io.Copy(ioutil.Discard, r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nbRead = len(input) - rd.Len()
+	if nbRead != len("789456zesd45679998") {
+		t.Error()
+	}
+}
+
+func TestDontPassEOD(t *testing.T) {
+	for _, fi := range []string{
+		ASCII85,
+		ASCIIHex,
+		RunLength,
+		LZW,
+		Flate,
+	} {
+		input := make([]byte, 1000)
+		_, _ = rand.Read(input)
+		fil, err := NewFilter(fi, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r, err := fil.Encode(bytes.NewReader(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		filtered, err := ioutil.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// add data passed EOD
+		additionalBytes := []byte("')(à'(ààç454658")
+		filtered = append(filtered, additionalBytes...)
+
+		re := bytes.NewReader(filtered)
+		toRead, err := fil.Decode(re)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = ioutil.ReadAll(toRead)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// we want to use the number of byte read from the
+		// filtered stream to detect EOD
+		if re.Len() != len(additionalBytes) {
+			t.Errorf("invalid number of bytes read with filter %s", fi)
+		}
+	}
+}

--- a/pkg/filter/runLengthDecode.go
+++ b/pkg/filter/runLengthDecode.go
@@ -19,23 +19,24 @@ package filter
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"io"
 	"io/ioutil"
+
+	"github.com/pkg/errors"
 )
+
+func unexpectedEOF(err error) error {
+	if err == io.EOF {
+		return errors.New("missing EOD marker in encoded stream")
+	}
+	return err
+}
 
 type runLengthDecode struct {
 	baseFilter
 }
 
 const eodRunLength = 0x80
-
-func unexpectedEOF(err error) error {
-	if err == io.EOF {
-		return errors.New("missing EOD marker in RunLength encoded stream")
-	}
-	return err
-}
 
 func (f runLengthDecode) decode(w io.ByteWriter, src io.ByteReader) error {
 


### PR DESCRIPTION
This PR slightly modifies the internal behavior of 5 filters (ASCII85, ASCIIHex, RunLength, LZW, Flate), to ensure that, given an input which implements io.ByteReader, the decoding of its data stops exactly at the EOD marker of the filter.
Such a change will be necessary to successfully parse content stream with inline image data. 

The external API is not changed, and the tests pass.

_Implementation details:_ 

LZW and Flate backing decoders already have such behavior, as indicated in their documentation: https://golang.org/pkg/compress/zlib/#NewReader says 

>  If r does not implement io.ByteReader, the decompressor may read more data than necessary from r.

and https://golang.org/pkg/compress/lzw/#NewReader

> If r does not also implement io.ByteReader, the decompressor may read more data than necessary from r.

The RunLength implementation is modified to use a `io.ByteReader`.

For ASCII85 and ASCIIHex, I implemented a "LimitedReader", very similar to the method `Reader.ReadSlice(delim byte)` provided by bufio (but bufio only supports a single byte as delimiter).
(Maybe the standard library provides a way to achieve the same result ?)

**Limitation**
pdfcpu/filter also supports decoding CCITT data, but this PR does not handle this filter.