### PR TITLE
Extract images in memory

### DIFF
--- a/pkg/api/extract.go
+++ b/pkg/api/extract.go
@@ -36,11 +36,13 @@ func ExtractImages(rs io.ReadSeeker, outDir, fileName string, selectedPages []st
 	return error
 }
 
+// Similar to ExtractImages but returnes in memory images as opposed to writing them to disk.
 func ExtractImagesInMem(rs io.ReadSeeker, selectedPages []string, conf *pdfcpu.Configuration) ([]pdfcpu.Image, error) {
 	return extractImages(rs, selectedPages, conf, true, "", "")
 }
 
 func extractImages(rs io.ReadSeeker, selectedPages []string, conf *pdfcpu.Configuration,
+	// in inMem is false, outDir and fileName won't be used. The boolean argument makes this behaviour more explicit
 	inMem bool, outDir, fileName string) ([]pdfcpu.Image, error) {
 	if rs == nil {
 		return nil, errors.New("pdfcpu: ExtractImages: Please provide rs")

--- a/pkg/api/extract.go
+++ b/pkg/api/extract.go
@@ -65,18 +65,7 @@ func ExtractImages(rs io.ReadSeeker, outDir, fileName string, selectedPages []st
 			return err
 		}
 		for _, img := range ii {
-			outFile := filepath.Join(outDir, fmt.Sprintf("%s_%d_%s.%s", fileName, i, img.Name, img.Type))
-			log.CLI.Printf("writing %s\n", outFile)
-			w, err := os.Create(outFile)
-			if err != nil {
-				return err
-			}
-			if _, err = io.Copy(w, img); err != nil {
-				return err
-			}
-			if err := w.Close(); err != nil {
-				return err
-			}
+			writeImageFile(outDir, fileName, img, i)
 		}
 	}
 
@@ -85,6 +74,22 @@ func ExtractImages(rs io.ReadSeeker, outDir, fileName string, selectedPages []st
 	log.Stats.Printf("XRefTable:\n%s\n", ctx)
 	pdfcpu.TimingStats("write images", durRead, durVal, durOpt, durWrite, durTotal)
 
+	return nil
+}
+
+func writeImageFile(outDir, fileName string, img pdfcpu.Image, pageNum int) error {
+	outFile := filepath.Join(outDir, fmt.Sprintf("%s_%d_%s.%s", fileName, pageNum, img.Name, img.Type))
+	log.CLI.Printf("writing %s\n", outFile)
+	w, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(w, img); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/api/test/extract_test.go
+++ b/pkg/api/test/extract_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
-	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 )
 
 func TestExtractImages(t *testing.T) {
@@ -44,12 +43,8 @@ func TestExtractImages(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s %s: %v\n", msg, fn, err)
 		}
-		imgs, err := api.ExtractImagesInMem(bytes.NewReader(content), nil, nil)
-		if err != nil {
+		if _, err := api.ExtractImagesInMem(bytes.NewReader(content), nil, nil); err != nil {
 			t.Fatalf("%s %s: %v\n", msg, fn, err)
-		}
-		if len(imgs) == 0 {
-			t.Fatalf("%s %s: No images extracted\n", msg, fn, err)
 		}
 	}
 	// Extract images for inFile starting with page 1 into outDir.

--- a/pkg/api/test/extract_test.go
+++ b/pkg/api/test/extract_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,15 +27,29 @@ import (
 	"testing"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 )
 
 func TestExtractImages(t *testing.T) {
 	msg := "TestExtractImages"
 	// Extract images for all pages into outDir.
 	for _, fn := range []string{"5116.DCT_Filter.pdf", "testImage.pdf", "go.pdf"} {
+		// Test writing files
 		fn = filepath.Join(inDir, fn)
 		if err := api.ExtractImagesFile(fn, outDir, nil, nil); err != nil {
 			t.Fatalf("%s %s: %v\n", msg, fn, err)
+		}
+		// Test in mem
+		content, err := ioutil.ReadFile(fn)
+		if err != nil {
+			t.Fatalf("%s %s: %v\n", msg, fn, err)
+		}
+		imgs, err := api.ExtractImagesInMem(bytes.NewReader(content), nil, nil)
+		if err != nil {
+			t.Fatalf("%s %s: %v\n", msg, fn, err)
+		}
+		if len(imgs) == 0 {
+			t.Fatalf("%s %s: No images extracted\n", msg, fn, err)
 		}
 	}
 	// Extract images for inFile starting with page 1 into outDir.


### PR DESCRIPTION
Hello, 

We were doing some experiments last friday with your library. We needed to extract images but didn't want to work with files so I made some modifications to the library to have a function that allows to work with images in memory, basically skipping the writing file parts.

I didn't modify the original interface at all so all existing code should work just as before.

I also added some testing code.

Greetings from the EndNote Click team.