### PR TITLE
Fix rename err

### DIFF
--- a/pkg/api/merge.go
+++ b/pkg/api/merge.go
@@ -182,13 +182,13 @@ func MergeAppendFile(inFiles []string, outFile string, conf *pdfcpu.Configuratio
 		if err = f2.Close(); err != nil {
 			return
 		}
-		if f1 != nil {
-			if err = os.Rename(tmpFile, outFile); err != nil {
+		for _, f := range ff {
+			if err = f.Close(); err != nil {
 				return
 			}
 		}
-		for _, f := range ff {
-			if err = f.Close(); err != nil {
+		if f1 != nil {
+			if err = os.Rename(tmpFile, outFile); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
Cannot change filename because the file is open (f1) and gives rename error. It must be closed before changing its name.