### PR TITLE
Fix error invalid encoding SymbolSetEncoding

### DIFF
--- a/pkg/pdfcpu/validate/font.go
+++ b/pkg/pdfcpu/validate/font.go
@@ -348,7 +348,7 @@ func validateFontEncoding(xRefTable *pdf.XRefTable, d pdf.Dict, dictName string,
 		return err
 	}
 
-	encodings := []string{"MacRomanEncoding", "MacExpertEncoding", "WinAnsiEncoding"}
+	encodings := []string{"MacRomanEncoding", "MacExpertEncoding", "WinAnsiEncoding", "SymbolSetEncoding"}
 	if xRefTable.ValidationMode == pdf.ValidationRelaxed {
 		encodings = append(encodings, "StandardEncoding")
 	}


### PR DESCRIPTION
I have a pdf file run extract with `error validateFontEncoding: invalid Encoding name: SymbolSetEncoding` so we need update font encoding
[test1.pdf](https://github.com/pdfcpu/pdfcpu/files/6512974/test1.pdf)
