### PR TITLE
Fix index-out-of-range error for PDF with corrupted dictionary

### DIFF
--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -1479,7 +1479,7 @@ func buildFilterPipeline(ctx *Context, filterArray, decodeParmsArr Array, decode
 		if !ok {
 			return nil, errors.New("pdfcpu: buildFilterPipeline: filterArray elements corrupt")
 		}
-		if decodeParms == nil || decodeParmsArr[i] == nil {
+		if decodeParms == nil || (len(filterArray) <= len(decodeParmsArr) && decodeParmsArr[i] == nil) {
 			filterPipeline = append(filterPipeline, PDFFilter{Name: filterName.Value(), DecodeParms: nil})
 			continue
 		}


### PR DESCRIPTION
Hi!

I'm encountering an issue in production with the latest release - 'index-out-of-range' error while processing a PDF with a seemingly corrupted document info dictionary.

I'm unable to share the PDF itself, but I can share a gist containing the `pdfcpu validate -vv` output (with some small redactions).

https://gist.github.com/christiannicola/f7757ed69cfe684f02ea4a774ad2b08f 

This PR fixes the runtime panic, and the method properly returns an error stating that the dictionary is corrupt - I'm assuming that that was the intention anyway.

Thank you for your consideration and this awesome library!