### PR TITLE
Watermark remove white objects

### DIFF
--- a/pkg/api/extract.go
+++ b/pkg/api/extract.go
@@ -270,6 +270,7 @@ func ExtractContent(rs io.ReadSeeker, outDir, fileName string, selectedPages []s
 		if r == nil {
 			continue
 		}
+
 		outFile := filepath.Join(outDir, fmt.Sprintf("%s_Content_page_%d.txt", fileName, p))
 		log.CLI.Printf("writing %s\n", outFile)
 		f, err := os.Create(outFile)

--- a/pkg/pdfcpu/stamp.go
+++ b/pkg/pdfcpu/stamp.go
@@ -1649,7 +1649,6 @@ func patchFirstContentStreamForWatermark(sd *StreamDict, gsID, xoID string, wm *
 		}
 
 		sd.Content = append(wmbb, sd.Content...)
-		//fmt.Printf("WATERMARKAFTER %s\n", sd.Content)
 		return sd.Encode()
 	}
 


### PR DESCRIPTION
To make watermark visiable on non-transparent document i have a method to remove all white rectangles.

I've have working example removing substrings of the content stream. Everything between "/Cs1 cs 1 1 1 sc" and "/Cs1 cs 0 0 0 sc" and everything between "1 1 1 rg", "0 0 0 rg" is removed.

This might be a little simplistic, but I it used to work quiet fine in a Mac app I made. I wonder if this could be part of pdfcpu or if you have comments on this.