### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/pdfcpu/process.go
+++ b/cmd/pdfcpu/process.go
@@ -19,7 +19,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -84,7 +84,7 @@ func printConfiguration(conf *pdfcpu.Configuration) {
 		os.Exit(1)
 	}
 	defer f.Close()
-	bb, err := ioutil.ReadAll(f)
+	bb, err := io.ReadAll(f)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "can't read %s", conf.Path)
 		os.Exit(1)

--- a/internal/corefont/metrics/gen.go
+++ b/internal/corefont/metrics/gen.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build ignore
 // +build ignore
 
 package main

--- a/internal/corefont/metrics/gen.go
+++ b/internal/corefont/metrics/gen.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -99,7 +98,7 @@ func writeCoreFontMetrics(w *bytes.Buffer) {
 	`
 	w.WriteString(s)
 	dir := "../Core14_AFMs"
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -200,8 +199,8 @@ func finish(w *bytes.Buffer, filename string) {
 	if err != nil {
 		log.Fatalf("format.Source: %v", err)
 	}
-	if err := ioutil.WriteFile(filename, out, 0660); err != nil {
-		log.Fatalf("ioutil.WriteFile: %v", err)
+	if err := os.WriteFile(filename, out, 0660); err != nil {
+		log.Fatalf("os.WriteFile: %v", err)
 	}
 }
 

--- a/pkg/api/test/api_test.go
+++ b/pkg/api/test/api_test.go
@@ -19,16 +19,14 @@ package test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
-
 	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 )
 
 var inDir, outDir, resDir string
@@ -46,7 +44,7 @@ func TestMain(m *testing.M) {
 	resDir = filepath.Join(inDir, "resources")
 	var err error
 
-	if outDir, err = ioutil.TempDir("", "pdfcpu_api_tests"); err != nil {
+	if outDir, err = os.MkdirTemp("", "pdfcpu_api_tests"); err != nil {
 		fmt.Printf("%v", err)
 		os.Exit(1)
 	}
@@ -100,7 +98,7 @@ func isPDF(filename string) bool {
 
 func AllPDFs(t *testing.T, dir string) []string {
 	t.Helper()
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("pdfFiles from %s: %v\n", dir, err)
 	}

--- a/pkg/api/test/attachments_test.go
+++ b/pkg/api/test/attachments_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -242,7 +242,7 @@ func TestAttachmentsLowLevel(t *testing.T) {
 	a := extractAttachment(t, msg, aa[0], ctx)
 
 	// Compare extracted attachment bytes.
-	gotBytes, err := ioutil.ReadAll(a)
+	gotBytes, err := io.ReadAll(a)
 	if err != nil {
 		t.Fatalf("%s extractAttachment: attachment %s no data available\n", msg, id)
 	}

--- a/pkg/api/test/extract_test.go
+++ b/pkg/api/test/extract_test.go
@@ -18,7 +18,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -187,7 +187,7 @@ func TestExtractContentLowLevel(t *testing.T) {
 	}
 
 	// Process page content.
-	bb, err := ioutil.ReadAll(r)
+	bb, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("%s readAll: %v\n", msg, err)
 	}
@@ -221,7 +221,7 @@ func TestExtractMetadataLowLevel(t *testing.T) {
 
 	// Process metadata.
 	for _, md := range mm {
-		bb, err := ioutil.ReadAll(md)
+		bb, err := io.ReadAll(md)
 		if err != nil {
 			t.Fatalf("%s metadata readAll: %v\n", msg, err)
 		}

--- a/pkg/api/test/fonts_test.go
+++ b/pkg/api/test/fonts_test.go
@@ -18,7 +18,7 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -139,7 +139,7 @@ func isTrueType(filename string) bool {
 
 func userFonts(t *testing.T, dir string) []string {
 	t.Helper()
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}

--- a/pkg/api/test/merge_test.go
+++ b/pkg/api/test/merge_test.go
@@ -19,7 +19,6 @@ package test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -87,7 +86,7 @@ func TestMergeToBuf(t *testing.T) {
 		t.Fatalf("%s: merge: %v\n", msg, err)
 	}
 
-	if err := ioutil.WriteFile(outFile, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(outFile, buf.Bytes(), 0644); err != nil {
 		t.Fatalf("%s: write: %v\n", msg, err)
 	}
 }

--- a/pkg/cli/test/cli_test.go
+++ b/pkg/cli/test/cli_test.go
@@ -18,7 +18,6 @@ package test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +45,7 @@ func TestMain(m *testing.M) {
 	fontDir = filepath.Join(inDir, "fonts")
 	var err error
 
-	if outDir, err = ioutil.TempDir("", "pdfcpu_cli_tests"); err != nil {
+	if outDir, err = os.MkdirTemp("", "pdfcpu_cli_tests"); err != nil {
 		fmt.Printf("%v", err)
 		os.Exit(1)
 	}
@@ -84,7 +83,7 @@ func isPDF(filename string) bool {
 
 func allPDFs(t *testing.T, dir string) []string {
 	t.Helper()
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("pdfFiles from %s: %v\n", dir, err)
 	}

--- a/pkg/filter/ascii85Decode.go
+++ b/pkg/filter/ascii85Decode.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/ascii85"
 	"io"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 )
@@ -34,7 +33,7 @@ const eodASCII85 = "~>"
 // Encode implements encoding for an ASCII85Decode filter.
 func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 
-	p, err := ioutil.ReadAll(r)
+	p, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +52,7 @@ func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an ASCII85Decode filter.
 func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
 
-	p, err := ioutil.ReadAll(r)
+	p, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +73,7 @@ func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
 
 	decoder := ascii85.NewDecoder(bytes.NewReader(p))
 
-	buf, err := ioutil.ReadAll(decoder)
+	buf, err := io.ReadAll(decoder)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/filter/asciiHexDecode.go
+++ b/pkg/filter/asciiHexDecode.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 )
 
 type asciiHexDecode struct {
@@ -32,7 +31,7 @@ const eodHexDecode = '>'
 // Encode implements encoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 
-	bb, err := ioutil.ReadAll(r)
+	bb, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +48,7 @@ func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
 
-	bb, err := ioutil.ReadAll(r)
+	bb, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -18,7 +18,7 @@ package filter_test
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -62,7 +62,7 @@ func encodeDecodeUsingFilterNamed(t *testing.T, filterName string) {
 	}
 	//t.Logf("decoded 1:  len:%d % X <%s>\n", c2.Len(), c2.Bytes(), c2.Bytes())
 
-	bb, err := ioutil.ReadAll(c2)
+	bb, err := io.ReadAll(c2)
 	if err != nil {
 		t.Fatalf("%v\n", err)
 	}
@@ -146,13 +146,13 @@ func testFile(t *testing.T, filterName, fileName string) {
 	}
 	defer golden.Close()
 
-	g, err := ioutil.ReadAll(golden)
+	g, err := io.ReadAll(golden)
 	if err != nil {
 		t.Errorf("%s: %v", fileName, err)
 		return
 	}
 
-	d, err := ioutil.ReadAll(dec)
+	d, err := io.ReadAll(dec)
 	if err != nil {
 		t.Errorf("%s: %v", fileName, err)
 		return

--- a/pkg/filter/runLengthDecode.go
+++ b/pkg/filter/runLengthDecode.go
@@ -19,7 +19,6 @@ package filter
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 )
 
 type runLengthDecode struct {
@@ -115,7 +114,7 @@ func (f runLengthDecode) encode(w io.ByteWriter, src []byte) {
 // Encode implements encoding for a RunLengthDecode filter.
 func (f runLengthDecode) Encode(r io.Reader) (io.Reader, error) {
 
-	p, err := ioutil.ReadAll(r)
+	p, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +128,7 @@ func (f runLengthDecode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an RunLengthDecode filter.
 func (f runLengthDecode) Decode(r io.Reader) (io.Reader, error) {
 
-	p, err := ioutil.ReadAll(r)
+	p, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/font/metrics.go
+++ b/pkg/font/metrics.go
@@ -19,7 +19,6 @@ package font
 import (
 	"encoding/gob"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -139,7 +138,7 @@ func isSupportedFontFile(filename string) bool {
 // LoadUserFonts loads any installed TTF or OTF font files.
 func LoadUserFonts() error {
 	//fmt.Printf("loading userFonts from %s\n", UserFontDir)
-	files, err := ioutil.ReadDir(UserFontDir)
+	files, err := os.ReadDir(UserFontDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/pdfcpu/configuration.go
+++ b/pkg/pdfcpu/configuration.go
@@ -19,7 +19,6 @@ package pdfcpu
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -196,7 +195,7 @@ func ensureConfigFileAt(path string) error {
 		f.Close()
 		s := fmt.Sprintf("#############################\n# pdfcpu %s        #\n# Created: %s #\n", VersionStr, time.Now().Format("2006-01-02 15:04"))
 		bb := append([]byte(s), configFileBytes...)
-		if err := ioutil.WriteFile(path, bb, os.ModePerm); err != nil {
+		if err := os.WriteFile(path, bb, os.ModePerm); err != nil {
 			return err
 		}
 		f, err = os.Open(path)

--- a/pkg/pdfcpu/create/create.go
+++ b/pkg/pdfcpu/create/create.go
@@ -19,7 +19,6 @@ package create
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/primitives"
@@ -219,7 +218,7 @@ func createAcroForm(
 
 func FromJSON(rd io.Reader, ctx *pdfcpu.Context) error {
 
-	bb, err := ioutil.ReadAll(rd)
+	bb, err := io.ReadAll(rd)
 	if err != nil {
 		return err
 	}

--- a/pkg/pdfcpu/image_test.go
+++ b/pkg/pdfcpu/image_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	outDir, err = ioutil.TempDir("", "pdfcpu_imageTests")
+	outDir, err = os.MkdirTemp("", "pdfcpu_imageTests")
 	if err != nil {
 		//fmt.Printf("%v", err)
 		os.Exit(1)
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 
 func streamDictForJPGFile(xRefTable *XRefTable, fileName string) (*StreamDict, error) {
 
-	bb, err := ioutil.ReadFile(fileName)
+	bb, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func compare(t *testing.T, fn1, fn2 string) {
 	}
 	defer f1.Close()
 
-	bb1, err := ioutil.ReadAll(f1)
+	bb1, err := io.ReadAll(f1)
 	if err != nil {
 		t.Errorf("%s: %v", fn1, err)
 		return
@@ -133,7 +133,7 @@ func compare(t *testing.T, fn1, fn2 string) {
 	}
 	defer f1.Close()
 
-	bb2, err := ioutil.ReadAll(f2)
+	bb2, err := io.ReadAll(f2)
 	if err != nil {
 		t.Errorf("%s: %v", fn2, err)
 		return
@@ -225,7 +225,7 @@ func read1BPCDeviceGrayFlateStreamDump(xRefTable *XRefTable, fileName string) (*
 	defer f.Close()
 
 	// Read in a flate encoded stream.
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +312,7 @@ func read8BPCDeviceCMYKFlateStreamDump(xRefTable *XRefTable, fileName string) (*
 	}
 	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pdfcpu/parseConfig.go
+++ b/pkg/pdfcpu/parseConfig.go
@@ -21,7 +21,6 @@ package pdfcpu
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -96,7 +95,7 @@ func parseConfigFile(r io.Reader, configPath string) error {
 	// Enforce default for old config files.
 	c.CheckFileNameExt = true
 
-	bb, err := ioutil.ReadAll(r)
+	bb, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/pdfcpu/parseConfig.go
+++ b/pkg/pdfcpu/parseConfig.go
@@ -1,3 +1,4 @@
+//go:build !js
 // +build !js
 
 /*

--- a/pkg/pdfcpu/readImage.go
+++ b/pkg/pdfcpu/readImage.go
@@ -24,8 +24,8 @@ import (
 	"image/jpeg"
 	_ "image/png"
 	"io"
-	"io/ioutil"
 	"math"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -42,7 +42,7 @@ func ImageFileName(fileName string) bool {
 
 // ImageFileNames returns a slice of image file names contained in dir.
 func ImageFileNames(dir string) ([]string, error) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -515,7 +515,7 @@ func createDCTImageObjectForJPEG(xRefTable *XRefTable, c image.Config, bb bytes.
 		return nil, 0, 0, errors.New("pdfcpu: unexpected color model for JPEG")
 	}
 
-	buf, err := ioutil.ReadAll(&bb)
+	buf, err := io.ReadAll(&bb)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -529,7 +529,7 @@ func CreateImageStreamDict(xRefTable *XRefTable, r io.Reader, gray, sepia bool) 
 
 	var bb bytes.Buffer
 	tee := io.TeeReader(r, &bb)
-	sniff, err := ioutil.ReadAll(tee)
+	sniff, err := io.ReadAll(tee)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/pdfcpu/stamp.go
+++ b/pkg/pdfcpu/stamp.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/url"
 	"os"
@@ -1025,7 +1024,7 @@ func setImageWatermark(s string, wm *Watermark) error {
 		return err
 	}
 	defer f.Close()
-	bb, err := ioutil.ReadAll(f)
+	bb, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/pkg/pdfcpu/streamdict.go
+++ b/pkg/pdfcpu/streamdict.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/pdfcpu/pdfcpu/pkg/filter"
 	"github.com/pdfcpu/pdfcpu/pkg/log"
@@ -187,7 +186,7 @@ func (sd *StreamDict) Encode() error {
 	}
 
 	var err error
-	if sd.Raw, err = ioutil.ReadAll(c); err != nil {
+	if sd.Raw, err = io.ReadAll(c); err != nil {
 		return err
 	}
 	streamLength := int64(len(sd.Raw))
@@ -256,7 +255,7 @@ func (sd *StreamDict) Decode() error {
 	}
 
 	var err error
-	if sd.Content, err = ioutil.ReadAll(c); err != nil {
+	if sd.Content, err = io.ReadAll(c); err != nil {
 		return err
 	}
 

--- a/pkg/pdfcpu/xreftable.go
+++ b/pkg/pdfcpu/xreftable.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -400,7 +399,7 @@ func (xRefTable *XRefTable) NewStreamDictForBuf(buf []byte) (*StreamDict, error)
 
 // NewStreamDictForFile creates a streamDict for filename.
 func (xRefTable *XRefTable) NewStreamDictForFile(filename string) (*StreamDict, error) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +409,7 @@ func (xRefTable *XRefTable) NewStreamDictForFile(filename string) (*StreamDict, 
 
 // NewEmbeddedStreamDict creates and returns an embeddedStreamDict containing the bytes represented by r.
 func (xRefTable *XRefTable) NewEmbeddedStreamDict(r io.Reader, modDate time.Time) (*IndirectRef, error) {
-	buf, err := ioutil.ReadAll(r)
+	buf, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR introduces two small changes:

1. Synchronizes `//go:build` lines with `// +build` lines by running `go fmt ./...`. 

2. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.