### PR TITLE
Fix resource leaks found by Svace static analyzer

### DIFF
--- a/pkg/api/annotate.go
+++ b/pkg/api/annotate.go
@@ -150,12 +150,6 @@ func AddAnnotationsAsIncrement(rws io.ReadWriteSeeker, selectedPages []string, a
 
 // AddAnnotationsFile adds annotations for selected pages to a PDF context read from inFile and writes the result to outFile.
 func AddAnnotationsFile(inFile, outFile string, selectedPages []string, ar pdfcpu.AnnotationRenderer, conf *pdfcpu.Configuration, incr bool) (err error) {
-	var f1, f2 *os.File
-
-	if f1, err = os.Open(inFile); err != nil {
-		return err
-	}
-
 	tmpFile := inFile + ".tmp"
 	if outFile != "" && inFile != outFile {
 		tmpFile = outFile
@@ -172,7 +166,14 @@ func AddAnnotationsFile(inFile, outFile string, selectedPages []string, ar pdfcp
 		}
 	}
 
+	var f1, f2 *os.File
+
+	if f1, err = os.Open(inFile); err != nil {
+		return err
+	}
+
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -280,12 +281,6 @@ func AddAnnotationsMapAsIncrement(rws io.ReadWriteSeeker, m map[int][]pdfcpu.Ann
 
 // AddAnnotationsMapFile adds annotations in m to corresponding pages of inFile and writes the result to outFile.
 func AddAnnotationsMapFile(inFile, outFile string, m map[int][]pdfcpu.AnnotationRenderer, conf *pdfcpu.Configuration, incr bool) (err error) {
-	var f1, f2 *os.File
-
-	if f1, err = os.Open(inFile); err != nil {
-		return err
-	}
-
 	tmpFile := inFile + ".tmp"
 	if outFile != "" && inFile != outFile {
 		tmpFile = outFile
@@ -302,7 +297,14 @@ func AddAnnotationsMapFile(inFile, outFile string, m map[int][]pdfcpu.Annotation
 		}
 	}
 
+	var f1, f2 *os.File
+
+	if f1, err = os.Open(inFile); err != nil {
+		return err
+	}
+
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -422,12 +424,6 @@ func RemoveAnnotationsAsIncrement(rws io.ReadWriteSeeker, selectedPages, ids []s
 // RemoveAnnotationsFile removes annotations for selected pages by id and object number
 // from a PDF context read from inFile and writes the result to outFile.
 func RemoveAnnotationsFile(inFile, outFile string, selectedPages, ids []string, objNrs []int, conf *pdfcpu.Configuration, incr bool) (err error) {
-	var f1, f2 *os.File
-
-	if f1, err = os.Open(inFile); err != nil {
-		return err
-	}
-
 	//fmt.Printf("RemoveAnnotationsFile: ids:%v objNrs:%v\n", ids, objNrs)
 
 	tmpFile := inFile + ".tmp"
@@ -446,7 +442,14 @@ func RemoveAnnotationsFile(inFile, outFile string, selectedPages, ids []string, 
 		}
 	}
 
+	var f1, f2 *os.File
+
+	if f1, err = os.Open(inFile); err != nil {
+		return err
+	}
+
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/attach.go
+++ b/pkg/api/attach.go
@@ -186,6 +186,7 @@ func AddAttachmentsFile(inFile, outFile string, files []string, coll bool, conf 
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -268,6 +269,7 @@ func RemoveAttachmentsFile(inFile, outFile string, files []string, conf *pdfcpu.
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/booklet.go
+++ b/pkg/api/booklet.go
@@ -119,6 +119,7 @@ func BookletFile(inFiles []string, outFile string, selectedPages []string, nup *
 	}
 
 	if f2, err = os.Create(outFile); err != nil {
+		f1.Close()
 		return err
 	}
 	log.CLI.Printf("writing %s...\n", outFile)

--- a/pkg/api/bookmarks.go
+++ b/pkg/api/bookmarks.go
@@ -78,6 +78,7 @@ func AddBookmarksFile(inFile, outFile string, bms []pdf.Bookmark, conf *pdf.Conf
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/boxes.go
+++ b/pkg/api/boxes.go
@@ -136,6 +136,7 @@ func AddBoxesFile(inFile, outFile string, selectedPages []string, pb *pdfcpu.Pag
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -217,6 +218,7 @@ func RemoveBoxesFile(inFile, outFile string, selectedPages []string, pb *pdfcpu.
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -298,6 +300,7 @@ func CropFile(inFile, outFile string, selectedPages []string, b *pdfcpu.Box, con
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/collect.go
+++ b/pkg/api/collect.go
@@ -77,6 +77,7 @@ func CollectFile(inFile, outFile string, selectedPages []string, conf *pdfcpu.Co
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/create.go
+++ b/pkg/api/create.go
@@ -124,6 +124,7 @@ func CreateFromJSONFile(jsonFile, inFile, outFile string, conf *pdfcpu.Configura
 	f1 = nil
 	if fileExists(inFile) {
 		if f1, err = os.Open(inFile); err != nil {
+			f0.Close()
 			return err
 		}
 		rs = f1
@@ -137,6 +138,10 @@ func CreateFromJSONFile(jsonFile, inFile, outFile string, conf *pdfcpu.Configura
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f0.Close()
+		if f1 != nil {
+			f1.Close()
+		}
 		return err
 	}
 

--- a/pkg/api/crypto.go
+++ b/pkg/api/crypto.go
@@ -59,6 +59,7 @@ func EncryptFile(inFile, outFile string, conf *pdfcpu.Configuration) (err error)
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -119,6 +120,7 @@ func DecryptFile(inFile, outFile string, conf *pdfcpu.Configuration) (err error)
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -183,6 +185,7 @@ func ChangeUserPasswordFile(inFile, outFile string, pwOld, pwNew string, conf *p
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -247,6 +250,7 @@ func ChangeOwnerPasswordFile(inFile, outFile string, pwOld, pwNew string, conf *
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/importImage.go
+++ b/pkg/api/importImage.go
@@ -131,6 +131,9 @@ func ImportImagesFile(imgFiles []string, outFile string, imp *pdfcpu.Import, con
 	for i, fn := range imgFiles {
 		f, err := os.Open(fn)
 		if err != nil {
+			if f1 != nil {
+				f1.Close()
+			}
 			return err
 		}
 		rc[i] = f
@@ -138,6 +141,9 @@ func ImportImagesFile(imgFiles []string, outFile string, imp *pdfcpu.Import, con
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		if f1 != nil {
+			f1.Close()
+		}
 		return err
 	}
 

--- a/pkg/api/keywords.go
+++ b/pkg/api/keywords.go
@@ -113,6 +113,7 @@ func AddKeywordsFile(inFile, outFile string, files []string, conf *pdf.Configura
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -192,6 +193,7 @@ func RemoveKeywordsFile(inFile, outFile string, keywords []string, conf *pdf.Con
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/merge.go
+++ b/pkg/api/merge.go
@@ -153,6 +153,9 @@ func MergeAppendFile(inFiles []string, outFile string, conf *pdfcpu.Configuratio
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		if f1 != nil {
+			f1.Close()
+		}
 		return err
 	}
 
@@ -164,6 +167,7 @@ func MergeAppendFile(inFiles []string, outFile string, conf *pdfcpu.Configuratio
 		log.CLI.Println(f)
 		f, err := os.Open(f)
 		if err != nil {
+			f2.Close()
 			return err
 		}
 		ff = append(ff, f)

--- a/pkg/api/nup.go
+++ b/pkg/api/nup.go
@@ -159,6 +159,9 @@ func NUpFile(inFiles []string, outFile string, selectedPages []string, nup *pdfc
 	}
 
 	if f2, err = os.Create(outFile); err != nil {
+		if f1 != nil {
+			f1.Close()
+		}
 		return err
 	}
 	log.CLI.Printf("writing %s...\n", outFile)

--- a/pkg/api/optimize.go
+++ b/pkg/api/optimize.go
@@ -81,6 +81,7 @@ func OptimizeFile(inFile, outFile string, conf *pdfcpu.Configuration) (err error
 	}
 
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/pages.go
+++ b/pkg/api/pages.go
@@ -88,6 +88,7 @@ func InsertPagesFile(inFile, outFile string, selectedPages []string, before bool
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -174,6 +175,7 @@ func RemovePagesFile(inFile, outFile string, selectedPages []string, conf *pdfcp
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/permissions.go
+++ b/pkg/api/permissions.go
@@ -113,6 +113,7 @@ func SetPermissionsFile(inFile, outFile string, conf *pdfcpu.Configuration) (err
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/properties.go
+++ b/pkg/api/properties.go
@@ -113,6 +113,7 @@ func AddPropertiesFile(inFile, outFile string, properties map[string]string, con
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -192,6 +193,7 @@ func RemovePropertiesFile(inFile, outFile string, properties []string, conf *pdf
 		tmpFile = outFile
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/rotate.go
+++ b/pkg/api/rotate.go
@@ -89,6 +89,7 @@ func RotateFile(inFile, outFile string, rotation int, selectedPages []string, co
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/stamp.go
+++ b/pkg/api/stamp.go
@@ -92,6 +92,7 @@ func AddWatermarksMapFile(inFile, outFile string, m map[int]*pdfcpu.Watermark, c
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -179,6 +180,7 @@ func AddWatermarksSliceMapFile(inFile, outFile string, m map[int][]*pdfcpu.Water
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -274,6 +276,7 @@ func AddWatermarksFile(inFile, outFile string, selectedPages []string, wm *pdfcp
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 
@@ -365,6 +368,7 @@ func RemoveWatermarksFile(inFile, outFile string, selectedPages []string, conf *
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 

--- a/pkg/api/trim.go
+++ b/pkg/api/trim.go
@@ -82,6 +82,7 @@ func TrimFile(inFile, outFile string, selectedPages []string, conf *pdfcpu.Confi
 		log.CLI.Printf("writing %s...\n", inFile)
 	}
 	if f2, err = os.Create(tmpFile); err != nil {
+		f1.Close()
 		return err
 	}
 


### PR DESCRIPTION
These are 35 resource leaks in 19 files of `api` package found by **Svace** static analysis tool. Most of them appear only on errors and have same pattern: a file is opened correctly - an error occurred - file isn't closed. 