### PR TITLE
Enhance PageCount to respect ValidationNone configuration

### DIFF
--- a/pkg/api/pages.go
+++ b/pkg/api/pages.go
@@ -206,8 +206,11 @@ func PageCount(rs io.ReadSeeker, conf *pdfcpu.Configuration) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if err := ValidateContext(ctx); err != nil {
-		return 0, err
+
+	if conf.ValidationMode != pdfcpu.ValidationNone {
+		if err = ValidateContext(ctx); err != nil {
+			return 0, err
+		}
 	}
 	return ctx.PageCount, nil
 }


### PR DESCRIPTION
Currently, PageCount ignores the configuration parameter ValidationNone.

The condition check has been implemented following the identical use case found in other API methods.