### PR TITLE
Fix JS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Go build
-        run: env CGO=0 GOOS=${{ matrix.target.goos }} GOARCH=${{ matrix.target.goarch }} go build ./cmd/pdfcpu
+        run: env CGO_ENABLED=0 GOOS=${{ matrix.target.goos }} GOARCH=${{ matrix.target.goarch }} go build ./cmd/pdfcpu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+on: [push, pull_request]
+name: Build
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - goos: js
+            goarch: wasm
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: linux
+            goarch: amd64
+          - goos: windows
+            goarch: amd64
+        go:
+          - '1.17.x'
+    runs-on: linux-latest
+
+    steps:
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - run: go version
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Go build
+        run: env CGO=0 GOOS=${{ matrix.target.goos }} GOARCH=${{ matrix.target.goarch }} go build ./cmd/pdfcpu

--- a/pkg/pdfcpu/parseConfig_js.go
+++ b/pkg/pdfcpu/parseConfig_js.go
@@ -216,7 +216,7 @@ func parseKeyValue(k, v string, c *Configuration) error {
 		err = handleTimestampFormat(v, c)
 
 	case "headerBufSize":
-		err = handleHeaderBufSize(k, v, c)
+		err = handleHeaderBufSize(v, c)
 
 	case "optimizeDuplicateContentStreams":
 		err = handleOptimizeDuplicateContentStreams(k, v, c)


### PR DESCRIPTION
Hey,

looks like WASM version stopped building some time ago.

```
$ env GOOS=js GOARCH=wasm go build
# github.com/pdfcpu/pdfcpu/pkg/pdfcpu
../../pkg/pdfcpu/parseConfig_js.go:219:28: too many arguments in call to handleHeaderBufSize
        have (string, string, *Configuration)
        want (string, *Configuration)
```

This fixes the problem. Maybe WASM build should be added to GH actions since it has some build-specific files?