### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@
 FROM golang:latest as builder
 
 # install
-RUN go get github.com/pdfcpu/pdfcpu/cmd/...
-WORKDIR $GOPATH/src/github.com/pdfcpu/pdfcpu/cmd/pdfcpu
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o pdfcpu .
+RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@latest
 
 ######## Start a new stage from scratch #######
 
@@ -17,7 +15,7 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=builder /go/src/github.com/pdfcpu/pdfcpu/cmd/pdfcpu .
+COPY --from=builder /go/bin .
 
 # Command to run the executable
 CMD ["./pdfcpu"]


### PR DESCRIPTION
It seems the go package now included a pre-built binary? (Or perhaps that's part of the install process? I don't know how go works...). Regardless, the dockerfile needs to be updated.

As an aside, it might be beneficial to publish a docker image. Aside from the convenience of using the container, it can also be a useful way for systems like [Renovate Bot](https://github.com/renovatebot/renovate) to track releases and keeps deps up to date.