### PR TITLE
Ignore null characters

### DIFF
--- a/pkg/pdfcpu/string.go
+++ b/pkg/pdfcpu/string.go
@@ -157,8 +157,8 @@ func Unescape(s string, enc bool) ([]byte, error) {
 			continue
 		}
 
-		// Ignore \eol line breaks.
-		if c == 0x0A {
+		// Ignore \eol line breaks and null characters.
+		if c == 0x0A || c == 0x00 {
 			esc = false
 			continue
 		}


### PR DESCRIPTION
I have a valid pdf file where pdfcpu fails validation because it doesn't handle null characters. Added fix.