### PR TITLE
add missing refactoring due to rename

### DIFF
--- a/pkg/pdfcpu/model/parseConfig_js.go
+++ b/pkg/pdfcpu/model/parseConfig_js.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 	"github.com/pkg/errors"
 )
 
@@ -73,11 +74,11 @@ func handleConfEol(v string, c *Configuration) error {
 	v1 := strings.ToLower(v)
 	switch v1 {
 	case "eollf":
-		c.Eol = EolLF
+		c.Eol = types.EolLF
 	case "eolcr":
-		c.Eol = EolCR
+		c.Eol = types.EolCR
 	case "eolcrlf":
-		c.Eol = EolCRLF
+		c.Eol = types.EolCRLF
 	default:
 		return errors.Errorf("invalid eol: %s", v)
 	}
@@ -116,7 +117,7 @@ func handleConfEncryptKeyLength(v string, c *Configuration) error {
 	if err != nil {
 		return errors.Errorf("encryptKeyLength is numeric, got: %s", v)
 	}
-	if !IntMemberOf(i, []int{40, 128, 256}) {
+	if !types.IntMemberOf(i, []int{40, 128, 256}) {
 		return errors.Errorf("encryptKeyLength possible values: 40, 128, 256, got: %s", v)
 	}
 	c.EncryptKeyLength = i
@@ -136,13 +137,13 @@ func handleConfUnit(v string, c *Configuration) error {
 	v1 := v
 	switch v1 {
 	case "points":
-		c.Unit = POINTS
+		c.Unit = types.POINTS
 	case "inches":
-		c.Unit = INCHES
+		c.Unit = types.INCHES
 	case "cm":
-		c.Unit = CENTIMETRES
+		c.Unit = types.CENTIMETRES
 	case "mm":
-		c.Unit = MILLIMETRES
+		c.Unit = types.MILLIMETRES
 	default:
 		return errors.Errorf("invalid unit: %s", v)
 	}


### PR DESCRIPTION
When trying to build [`henrixapp/pdfcomprezzor`](https://github.com/henrixapp/pdfcomprezzor) with version 0.4.0 I got the following error:
```
$ GOOS=js GOARCH=wasm go build -o pdfcomprezzor.wasm                                                                                                1 ↵

# github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:76:11: undefined: EolLF
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:78:11: undefined: EolCR
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:80:11: undefined: EolCRLF
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:119:6: undefined: IntMemberOf
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:139:12: undefined: POINTS
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:141:12: undefined: INCHES
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:143:12: undefined: CENTIMETRES
../../../go/pkg/mod/github.com/pdfcpu/pdfcpu@v0.4.0/pkg/pdfcpu/model/parseConfig_js.go:145:12: undefined: MILLIMETRES
```

This was due to a missing refactoring in `parseConfig_js.go` which this PR does.
I extrapolated it from the changes made to to `parseConfig.go` in https://github.com/pdfcpu/pdfcpu/commit/363a1f2f31544b82aedcf0e14fafe69e273a5fb.

Thank you for all your amazing work on pdfcpu 🤗 💯
