### PR TITLE
fix(api): Protects DisableConfigDir from concurrent access using mutex

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -37,6 +37,7 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/pdfcpu/pdfcpu/pkg/log"
@@ -161,11 +162,19 @@ func EnsureDefaultConfigAt(path string) error {
 	return model.EnsureDefaultConfigAt(path)
 }
 
+var (
+	// mutexDisableConfigDir protects DisableConfigDir from concurrent access.
+	// NOTE: This is not a guard for model.ConfigPath variable.
+	mutexDisableConfigDir sync.Mutex
+)
+
 // DisableConfigDir disables the configuration directory.
 // Any needed default configuration will be loaded from configuration.go
 // Since the config dir also contains the user font dir, this also limits font usage to the default core font set
 // No user fonts will be available.
 func DisableConfigDir() {
+	mutexDisableConfigDir.Lock()
+	defer mutexDisableConfigDir.Unlock()
 	// Call if you don't want to use a specific configuration
 	// and also do not need to use user fonts.
 	model.ConfigPath = "disable"

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+)
+
+func TestDisableConfigDir(t *testing.T) {
+	t.Parallel()
+	DisableConfigDir()
+
+	if model.ConfigPath != "disable" {
+		t.Errorf("model.ConfigPath != \"disable\" (%s)", model.ConfigPath)
+	}
+}
+
+func TestDisableConfigDir_Parallel(t *testing.T) {
+	t.Parallel()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			DisableConfigDir()
+		}()
+	}
+	wg.Wait()
+	t.Log("DisableConfigDir is passed")
+}

--- a/pkg/pdfcpu/model/configuration.go
+++ b/pkg/pdfcpu/model/configuration.go
@@ -207,6 +207,10 @@ type Configuration struct {
 //
 //	default:	Ensure config dir at default location
 //	disable:	Disable config dir usage
+//
+// WARNING: This is a global variable and should be safe for concurrent use.
+// If you want to change disable config dir,
+// call api.DisableConfigDir() that is concurrency safe instead of changing directly.
 var ConfigPath string = "default"
 
 var loadedDefaultConfig *Configuration


### PR DESCRIPTION
## Thank you for your contribution!

1. Please do not create a Pull Request without creating an issue first.

2. **Any** change needs to be discussed before proceeding.

3. Please provide enough information for PR review.

`model.ConfigPath` is a global variable, so data races can happen if call `api.DisableConfigDir()` parallely.
see more: https://go.dev/doc/articles/race_detector#Primitive_unprotected_variable

### reproduction
```shell
go test -race -run DisableConfigDir ./pkg/api/...
==================
WARNING: DATA RACE
Write at 0x000102907350 by goroutine 16:
  github.com/pdfcpu/pdfcpu/pkg/api.DisableConfigDir()
      /Users/yoshiki.nakagawa/repos/src/github.com/pdfcpu/pdfcpu/pkg/api/api.go:180 +0x64
  github.com/pdfcpu/pdfcpu/pkg/api.TestDisableConfigDir_Parallel.func1()
      /Users/yoshiki.nakagawa/repos/src/github.com/pdfcpu/pdfcpu/pkg/api/api_test.go:27 +0x58

Previous write at 0x000102907350 by goroutine 6:
  github.com/pdfcpu/pdfcpu/pkg/api.DisableConfigDir()
      /Users/yoshiki.nakagawa/repos/src/github.com/pdfcpu/pdfcpu/pkg/api/api.go:180 +0x38
  github.com/pdfcpu/pdfcpu/pkg/api.TestDisableConfigDir()
      /Users/yoshiki.nakagawa/repos/src/github.com/pdfcpu/pdfcpu/pkg/api/api_test.go:12 +0x2c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x40

Goroutine 16 (running) created at:
  github.com/pdfcpu/pdfcpu/pkg/api.TestDisableConfigDir_Parallel()
      /Users/yoshiki.nakagawa/repos/src/github.com/pdfcpu/pdfcpu/pkg/api/api_test.go:25 +0x58
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x188
  testing.(*T).Run.func1()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x40

Goroutine 6 (finished) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x5e4
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:2036 +0x80
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x188
  testing.runTests()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:2034 +0x700
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1906 +0x950
  main.main()
      _testmain.go:49 +0x300
==================
--- FAIL: TestDisableConfigDir_Parallel (0.00s)
    api_test.go:31: DisableConfigDir is passed
    testing.go:1446: race detected during execution of test
FAIL
FAIL	github.com/pdfcpu/pdfcpu/pkg/api	0.370s
ok  	github.com/pdfcpu/pdfcpu/pkg/api/test	2.794s [no tests to run]
FAIL
```

⚠️ This is not a perfect solution as global variables can be changed from anywhere.
Unfortunately, I haven't solution protects this settings without breaking changes.

5. Fixes # ?
