### PR TITLE
Fix concurrent write to map userfontmetrics

### DIFF
--- a/pkg/api/font.go
+++ b/pkg/api/font.go
@@ -200,7 +200,9 @@ func planeString(i int) string {
 // CreateUserFontDemoFiles creates single page PDF for each Unicode plane covered.
 func CreateUserFontDemoFiles(dir, fn string) error {
 	w, h := 7800, 7800
+	font.UserFontMetricsLock.RLock()
 	ttf, ok := font.UserFontMetrics[fn]
+	font.UserFontMetricsLock.RUnlock()
 	if !ok {
 		return errors.Errorf("pdfcpu: font %s not available\n", fn)
 	}

--- a/pkg/pdfcpu/font/fontDict.go
+++ b/pkg/pdfcpu/font/fontDict.go
@@ -739,7 +739,10 @@ func usedGIDsFromCMap(cMap string) ([]uint16, error) {
 // UpdateUserfont updates the fontdict for fontName via supplied font resource.
 func UpdateUserfont(xRefTable *model.XRefTable, fontName string, f model.FontResource) error {
 
+	font.UserFontMetricsLock.RLock()
 	ttf, ok := font.UserFontMetrics[fontName]
+	font.UserFontMetricsLock.RUnlock()
+
 	if !ok {
 		return errors.Errorf("pdfcpu: userfont %s not available", fontName)
 	}
@@ -839,7 +842,9 @@ func CIDFontSpecialEncDict(xRefTable *model.XRefTable, ttf font.TTFLight, baseFo
 
 func type0CJKFontDict(xRefTable *model.XRefTable, fontName, lang, script string, indRef *types.IndirectRef) (*types.IndirectRef, error) {
 
+	font.UserFontMetricsLock.RLock()
 	ttf, ok := font.UserFontMetrics[fontName]
+	font.UserFontMetricsLock.RUnlock()
 	if !ok {
 		return nil, errors.Errorf("pdfcpu: font %s not available", fontName)
 	}
@@ -876,7 +881,9 @@ func type0FontDict(xRefTable *model.XRefTable, fontName, lang string, subFont bo
 	// Combines a CIDFont and a CMap to produce a font whose glyphs may be accessed
 	// by means of variable-length character codes in a string to be shown.
 
+	font.UserFontMetricsLock.RLock()
 	ttf, ok := font.UserFontMetrics[fontName]
+	font.UserFontMetricsLock.RUnlock()
 	if !ok {
 		return nil, errors.Errorf("pdfcpu: font %s not available", fontName)
 	}
@@ -923,8 +930,9 @@ func type0FontDict(xRefTable *model.XRefTable, fontName, lang string, subFont bo
 }
 
 func trueTypeFontDict(xRefTable *model.XRefTable, fontName, fontLang string) (*types.IndirectRef, error) {
-
+	font.UserFontMetricsLock.RLock()
 	ttf, ok := font.UserFontMetrics[fontName]
+	font.UserFontMetricsLock.RUnlock()
 	if !ok {
 		return nil, errors.Errorf("pdfcpu: font %s not available", fontName)
 	}

--- a/pkg/pdfcpu/model/text.go
+++ b/pkg/pdfcpu/model/text.go
@@ -191,7 +191,11 @@ func PrepBytes(xRefTable *XRefTable, s, fontName string, cjk, rtl bool) string {
 				xRefTable.UsedGIDs[fontName] = map[uint16]bool{}
 				usedGIDs = xRefTable.UsedGIDs[fontName]
 			}
+
+			font.UserFontMetricsLock.RLock()
 			ttf := font.UserFontMetrics[fontName]
+			font.UserFontMetricsLock.RUnlock()
+
 			for _, r := range s {
 				gid, ok := ttf.Chars[uint32(r)]
 				if ok {

--- a/pkg/pdfcpu/primitives/font.go
+++ b/pkg/pdfcpu/primitives/font.go
@@ -55,7 +55,9 @@ func (f *FormFont) validateISO639() error {
 }
 
 func (f *FormFont) validateScriptSupport() error {
+	font.UserFontMetricsLock.RLock()
 	fd, ok := font.UserFontMetrics[f.Name]
+	font.UserFontMetricsLock.RUnlock()
 	if !ok {
 		return errors.Errorf("pdfcpu: userfont %s not available", f.Name)
 	}


### PR DESCRIPTION
UserFontMetrics map is not safe to use concurrently, this pull request uses a lock to ensure it is thread safe.
Fixes: https://github.com/pdfcpu/pdfcpu/issues/499