### PR TITLE
Allow the use of stamps/watermarks loaded into memory

### DIFF
--- a/pkg/pdfcpu/model/watermark.go
+++ b/pkg/pdfcpu/model/watermark.go
@@ -62,6 +62,7 @@ type Watermark struct {
 	TextLines         []string            // display multiple lines of text.
 	URL               string              // overlay link annotation for stamps.
 	FileName          string              // display pdf page or png image.
+	PDF               io.ReadSeeker       // reader for PDF watermark.
 	Image             io.Reader           // reader for image watermark.
 	Page              int                 // the page number of a PDF file. 0 means multistamp/multiwatermark.
 	OnTop             bool                // if true this is a STAMP else this is a WATERMARK.

--- a/pkg/pdfcpu/stamp.go
+++ b/pkg/pdfcpu/stamp.go
@@ -646,7 +646,15 @@ func createPDFRes(ctx, otherCtx *model.Context, pageNr int, migrated map[int]int
 
 func createPDFResForWM(ctx *model.Context, wm *model.Watermark) error {
 	// Note: The stamp pdf is assumed to be valid!
-	otherCtx, err := ReadFile(wm.FileName, model.NewDefaultConfiguration())
+	var otherCtx *model.Context
+	var err error
+
+	if wm.PDF != nil {
+		otherCtx, err = Read(wm.PDF, model.NewDefaultConfiguration())
+	} else {
+		otherCtx, err = ReadFile(wm.FileName, model.NewDefaultConfiguration())
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Use stamps/watermarks loaded into memory

Currently it is possible to load PDF stamps/watermarks only from files. In some cases it would be convenient to use already loaded into memory files (similar was discussed in #472).

This PR proposes to extend the `Watermark` model with additional filed `PDF` which can be used to provide an already loaded PDF stamp/watermark as a `io.ReadSeeker`.

The corresponding code to load it in `createPDFResForWM` is also provided.