### PR TITLE
Shift placement ot multistamp/multiwatermark by several pages

### DIFF
--- a/pkg/pdfcpu/model/watermark.go
+++ b/pkg/pdfcpu/model/watermark.go
@@ -64,6 +64,7 @@ type Watermark struct {
 	FileName          string              // display pdf page or png image.
 	Image             io.Reader           // reader for image watermark.
 	Page              int                 // the page number of a PDF file. 0 means multistamp/multiwatermark.
+	SkipPages         int                 // number of pages in destination PDF to skip before starting multistamp/multiwatermark.
 	OnTop             bool                // if true this is a STAMP else this is a WATERMARK.
 	InpUnit           types.DisplayUnit   // input display unit.
 	Pos               types.Anchor        // position anchor, one of tl,tc,tr,l,c,r,bl,bc,br.

--- a/pkg/pdfcpu/stamp.go
+++ b/pkg/pdfcpu/stamp.go
@@ -607,15 +607,19 @@ func createPDFRes(ctx, otherCtx *model.Context, pageNr int, migrated map[int]int
 	pdfRes := model.PdfResources{}
 	xRefTable := ctx.XRefTable
 	otherXRefTable := otherCtx.XRefTable
+	otherPageNr := pageNr - wm.SkipPages
+	if otherPageNr <= 0 {
+		otherPageNr = 1
+	}
 
 	// Locate page dict & resource dict of PDF stamp.
 	consolidateRes := true
-	d, _, inhPAttrs, err := otherXRefTable.PageDict(pageNr, consolidateRes)
+	d, _, inhPAttrs, err := otherXRefTable.PageDict(otherPageNr, consolidateRes)
 	if err != nil {
 		return err
 	}
 	if d == nil {
-		return errors.Errorf("pdfcpu: unknown page number: %d\n", pageNr)
+		return errors.Errorf("pdfcpu: unknown page number: %d\n", otherPageNr)
 	}
 
 	// Retrieve content stream bytes of page dict.
@@ -662,8 +666,8 @@ func createPDFResForWM(ctx *model.Context, wm *model.Watermark) error {
 			return err
 		}
 	} else {
-		j := otherCtx.PageCount
-		if ctx.PageCount < otherCtx.PageCount {
+		j := otherCtx.PageCount + wm.SkipPages
+		if ctx.PageCount < j {
 			j = ctx.PageCount
 		}
 		for i := 1; i <= j; i++ {


### PR DESCRIPTION
A possible implementation of #733.

The idea is to be able to configure the `Watermark` for how many pages have to be skipped before applying multistamp/multiwatermark.

My understanding of the internals of PDF is not that good, thus I suspect that this implementation is quite brute force.