### PR TITLE
Fix bugs

### DIFF
--- a/pkg/pdfcpu/model/equal.go
+++ b/pkg/pdfcpu/model/equal.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 	"github.com/pkg/errors"
+
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 )
 
 // EqualObjects returns true if two objects are equal in the context of given xrefTable.
@@ -141,7 +142,7 @@ func equalFontNames(v1, v2 types.Object, xRefTable *XRefTable) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	bf2 := v2.(types.Name)
+	bf2, ok := v2.(types.Name)
 	if !ok {
 		return false, errors.Errorf("equalFontNames: type cast problem")
 	}

--- a/pkg/pdfcpu/model/parse.go
+++ b/pkg/pdfcpu/model/parse.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pkg/errors"
+
 	"github.com/pdfcpu/pdfcpu/pkg/log"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -1031,7 +1032,7 @@ func ParseXRefStreamDict(sd *types.StreamDict) (*types.XRefStreamDict, error) {
 			log.Parse.Println("ParseXRefStreamDict: using index dict")
 		}
 
-		if len(indArr)%2 > 1 {
+		if len(indArr)%2 != 0 {
 			return nil, errXrefStreamCorruptIndex
 		}
 

--- a/pkg/pdfcpu/types/streamdict.go
+++ b/pkg/pdfcpu/types/streamdict.go
@@ -71,7 +71,7 @@ func (sd StreamDict) Clone() Object {
 	for k, v := range sd.FilterPipeline {
 		f := PDFFilter{}
 		f.Name = v.Name
-		if f.DecodeParms != nil {
+		if v.DecodeParms != nil {
 			f.DecodeParms = v.DecodeParms.Clone().(Dict)
 		}
 		pl[k] = f


### PR DESCRIPTION
PR for the Issue #761 

Changes: 
1. replace `f.DecodeParms != nil -> v.DecodeParms != nil` in the `StreamDict.Clone` method
2. replace `len(indArr)%2 > 1 -> len(indArr)%2 != 0` in the `ParseXRefStreamDict` method
3. add missed type check in the `equalFontNames`