### PR TITLE
Avoid calling "DecodeName" when parsing dictionaries.

### DIFF
--- a/pkg/pdfcpu/model/parse_dict_test.go
+++ b/pkg/pdfcpu/model/parse_dict_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package model
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -145,6 +147,19 @@ func doTestParseDictWithComments(t *testing.T) {
 
 }
 
+func doTestLargeDicts(t *testing.T) {
+	// Make sure parsing large dictionaries is fast. Found a file in the wild
+	// that has two dictionaries with about 200.000 entries each.
+	var sb strings.Builder
+	sb.WriteString("<<")
+	for i := 0; i < 50000; i++ {
+		sb.WriteString(fmt.Sprintf("/Key%d (Value)", i))
+	}
+	sb.WriteString(">>")
+
+	doTestParseDictOK(sb.String(), t)
+}
+
 func TestParseDict(t *testing.T) {
 	doTestParseDictGeneral(t)
 	doTestParseDictNameObjects(t)
@@ -156,4 +171,5 @@ func TestParseDict(t *testing.T) {
 	doTestParseDictNumerics(t)
 	doTestParseDictIndirectRefs(t)
 	doTestParseDictWithComments(t)
+	doTestLargeDicts(t)
 }


### PR DESCRIPTION
If no name with a "#" has been added before, it's not necessary to go through the expensive "Insert" call that will call "DecodeName" for every previously added key.

Fixes #775

Even better would be to keep the `hasNames` flag in the `Dict` object so other calls to `Find` could also benefit, but this is not possible with the aliased type.