### PR TITLE
Avoid copying from "bytes.Buffer" to get underlying bytes.

### DIFF
--- a/pkg/filter/ascii85Decode.go
+++ b/pkg/filter/ascii85Decode.go
@@ -33,14 +33,11 @@ const eodASCII85 = "~>"
 // Encode implements encoding for an ASCII85Decode filter.
 func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 
-	var b1 bytes.Buffer
-	if _, err := io.Copy(&b1, r); err != nil {
-		return nil, err
-	}
-
 	b2 := &bytes.Buffer{}
 	encoder := ascii85.NewEncoder(b2)
-	encoder.Write(b1.Bytes())
+	if _, err := io.Copy(encoder, r); err != nil {
+		return nil, err
+	}
 	encoder.Close()
 
 	// Add eod sequence
@@ -52,12 +49,10 @@ func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an ASCII85Decode filter.
 func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
 
-	var b1 bytes.Buffer
-	if _, err := io.Copy(&b1, r); err != nil {
+	bb, err := getReaderBytes(r)
+	if err != nil {
 		return nil, err
 	}
-
-	bb := b1.Bytes()
 
 	// fmt.Printf("dump:\n%s", hex.Dump(bb))
 

--- a/pkg/filter/asciiHexDecode.go
+++ b/pkg/filter/asciiHexDecode.go
@@ -31,12 +31,10 @@ const eodHexDecode = '>'
 // Encode implements encoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
+	bb, err := getReaderBytes(r)
+	if err != nil {
 		return nil, err
 	}
-
-	bb := buf.Bytes()
 
 	dst := make([]byte, hex.EncodedLen(len(bb)))
 	hex.Encode(dst, bb)
@@ -50,12 +48,10 @@ func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
+	bb, err := getReaderBytes(r)
+	if err != nil {
 		return nil, err
 	}
-
-	bb := buf.Bytes()
 
 	var p []byte
 

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -18,6 +18,7 @@ limitations under the License.
 package filter
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/pdfcpu/pdfcpu/pkg/log"
@@ -97,4 +98,20 @@ func List() []string {
 
 type baseFilter struct {
 	parms map[string]int
+}
+
+func getReaderBytes(r io.Reader) ([]byte, error) {
+	var bb []byte
+	if buf, ok := r.(*bytes.Buffer); ok {
+		bb = buf.Bytes()
+	} else {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			return nil, err
+		}
+
+		bb = buf.Bytes()
+	}
+
+	return bb, nil
 }

--- a/pkg/filter/runLengthDecode.go
+++ b/pkg/filter/runLengthDecode.go
@@ -112,13 +112,13 @@ func (f runLengthDecode) encode(w io.ByteWriter, src []byte) {
 // Encode implements encoding for a RunLengthDecode filter.
 func (f runLengthDecode) Encode(r io.Reader) (io.Reader, error) {
 
-	var b1 bytes.Buffer
-	if _, err := io.Copy(&b1, r); err != nil {
+	b1, err := getReaderBytes(r)
+	if err != nil {
 		return nil, err
 	}
 
 	var b2 bytes.Buffer
-	f.encode(&b2, b1.Bytes())
+	f.encode(&b2, b1)
 
 	return &b2, nil
 }
@@ -126,13 +126,13 @@ func (f runLengthDecode) Encode(r io.Reader) (io.Reader, error) {
 // Decode implements decoding for an RunLengthDecode filter.
 func (f runLengthDecode) Decode(r io.Reader) (io.Reader, error) {
 
-	var b1 bytes.Buffer
-	if _, err := io.Copy(&b1, r); err != nil {
+	b1, err := getReaderBytes(r)
+	if err != nil {
 		return nil, err
 	}
 
 	var b2 bytes.Buffer
-	f.decode(&b2, b1.Bytes())
+	f.decode(&b2, b1)
 
 	return &b2, nil
 }

--- a/pkg/pdfcpu/types/streamdict.go
+++ b/pkg/pdfcpu/types/streamdict.go
@@ -195,12 +195,16 @@ func (sd *StreamDict) Encode() error {
 		b = c
 	}
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, c); err != nil {
-		return err
-	}
+	if bb, ok := c.(*bytes.Buffer); ok {
+		sd.Raw = bb.Bytes()
+	} else {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, c); err != nil {
+			return err
+		}
 
-	sd.Raw = buf.Bytes()
+		sd.Raw = buf.Bytes()
+	}
 
 	streamLength := int64(len(sd.Raw))
 	sd.StreamLength = &streamLength
@@ -289,12 +293,16 @@ func (sd *StreamDict) Decode() error {
 		b = c
 	}
 
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, c); err != nil {
-		return err
-	}
+	if bb, ok := c.(*bytes.Buffer); ok {
+		sd.Content = bb.Bytes()
+	} else {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, c); err != nil {
+			return err
+		}
 
-	sd.Content = buf.Bytes()
+		sd.Content = buf.Bytes()
+	}
 
 	return nil
 }


### PR DESCRIPTION
As described in #810, this PR removes the unnecessary copying from `bytes.Buffer` to get the `[]byte` data where possible.

Fixes #810