### PR TITLE
Lazily parse ObjectStream objects.

### DIFF
--- a/pkg/filter/ascii85Decode.go
+++ b/pkg/filter/ascii85Decode.go
@@ -48,6 +48,10 @@ func (f ascii85Decode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an ASCII85Decode filter.
 func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
+
+func (f ascii85Decode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 
 	bb, err := getReaderBytes(r)
 	if err != nil {
@@ -71,8 +75,14 @@ func (f ascii85Decode) Decode(r io.Reader) (io.Reader, error) {
 	decoder := ascii85.NewDecoder(bytes.NewReader(bb))
 
 	var b2 bytes.Buffer
-	if _, err := io.Copy(&b2, decoder); err != nil {
-		return nil, err
+	if maxLen < 0 {
+		if _, err := io.Copy(&b2, decoder); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := io.CopyN(&b2, decoder, maxLen); err != nil {
+			return nil, err
+		}
 	}
 
 	return &b2, nil

--- a/pkg/filter/asciiHexDecode.go
+++ b/pkg/filter/asciiHexDecode.go
@@ -47,7 +47,10 @@ func (f asciiHexDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an ASCIIHexDecode filter.
 func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
 
+func (f asciiHexDecode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 	bb, err := getReaderBytes(r)
 	if err != nil {
 		return nil, err
@@ -70,9 +73,12 @@ func (f asciiHexDecode) Decode(r io.Reader) (io.Reader, error) {
 		p = append(p, '0')
 	}
 
-	dst := make([]byte, hex.DecodedLen(len(p)))
+	if maxLen < 0 {
+		maxLen = int64(hex.DecodedLen(len(p)))
+	}
+	dst := make([]byte, maxLen)
 
-	if _, err := hex.Decode(dst, p); err != nil {
+	if _, err := hex.Decode(dst, p[:maxLen*2]); err != nil {
 		return nil, err
 	}
 

--- a/pkg/filter/ccittDecode.go
+++ b/pkg/filter/ccittDecode.go
@@ -37,6 +37,10 @@ func (f ccittDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for a CCITTDecode filter.
 func (f ccittDecode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
+
+func (f ccittDecode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 	if log.TraceEnabled() {
 		log.Trace.Println("DecodeCCITT begin")
 	}

--- a/pkg/filter/dctDecode.go
+++ b/pkg/filter/dctDecode.go
@@ -35,7 +35,10 @@ func (f dctDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for a DCTDecode filter.
 func (f dctDecode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
 
+func (f dctDecode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 	im, err := jpeg.Decode(r)
 	if err != nil {
 		return nil, err

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -45,6 +45,10 @@ var ErrUnsupportedFilter = errors.New("pdfcpu: filter not supported")
 type Filter interface {
 	Encode(r io.Reader) (io.Reader, error)
 	Decode(r io.Reader) (io.Reader, error)
+	// DecodeLength will decode at least maxLen bytes. For filters where decoding
+	// parts doesn't make sense (e.g. DCT), the whole stream is decoded.
+	// If maxLen < 0 is passed, the whole stream is decoded.
+	DecodeLength(r io.Reader, maxLen int64) (io.Reader, error)
 }
 
 // NewFilter returns a filter for given filterName and an optional parameter dictionary.

--- a/pkg/filter/lzwDecode.go
+++ b/pkg/filter/lzwDecode.go
@@ -59,6 +59,10 @@ func (f lzwDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an LZWDecode filter.
 func (f lzwDecode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
+
+func (f lzwDecode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 	if log.TraceEnabled() {
 		log.Trace.Println("DecodeLZW begin")
 	}
@@ -77,7 +81,13 @@ func (f lzwDecode) Decode(r io.Reader) (io.Reader, error) {
 	defer rc.Close()
 
 	var b bytes.Buffer
-	written, err := io.Copy(&b, rc)
+	var written int64
+	var err error
+	if maxLen < 0 {
+		written, err = io.Copy(&b, rc)
+	} else {
+		written, err = io.CopyN(&b, rc, maxLen)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/filter/runLengthDecode.go
+++ b/pkg/filter/runLengthDecode.go
@@ -25,7 +25,8 @@ type runLengthDecode struct {
 	baseFilter
 }
 
-func (f runLengthDecode) decode(w io.ByteWriter, src []byte) {
+func (f runLengthDecode) decode(w io.ByteWriter, src []byte, maxLen int64) {
+	var written int64
 
 	for i := 0; i < len(src); {
 		b := src[i]
@@ -37,14 +38,24 @@ func (f runLengthDecode) decode(w io.ByteWriter, src []byte) {
 		if b < 0x80 {
 			c := int(b) + 1
 			for j := 0; j < c; j++ {
+				if maxLen >= 0 && maxLen == written {
+					break
+				}
+
 				w.WriteByte(src[i])
+				written++
 				i++
 			}
 			continue
 		}
 		c := 257 - int(b)
 		for j := 0; j < c; j++ {
+			if maxLen >= 0 && maxLen == written {
+				break
+			}
+
 			w.WriteByte(src[i])
+			written++
 		}
 		i++
 	}
@@ -125,6 +136,10 @@ func (f runLengthDecode) Encode(r io.Reader) (io.Reader, error) {
 
 // Decode implements decoding for an RunLengthDecode filter.
 func (f runLengthDecode) Decode(r io.Reader) (io.Reader, error) {
+	return f.DecodeLength(r, -1)
+}
+
+func (f runLengthDecode) DecodeLength(r io.Reader, maxLen int64) (io.Reader, error) {
 
 	b1, err := getReaderBytes(r)
 	if err != nil {
@@ -132,7 +147,7 @@ func (f runLengthDecode) Decode(r io.Reader) (io.Reader, error) {
 	}
 
 	var b2 bytes.Buffer
-	f.decode(&b2, b1)
+	f.decode(&b2, b1, maxLen)
 
 	return &b2, nil
 }

--- a/pkg/filter/runLengthDecode_test.go
+++ b/pkg/filter/runLengthDecode_test.go
@@ -71,7 +71,7 @@ func TestRunLengthEncoding(t *testing.T) {
 		compare(t, enc.Bytes(), []byte(tt.enc))
 
 		var raw bytes.Buffer
-		f.decode(&raw, enc.Bytes())
+		f.decode(&raw, enc.Bytes(), -1)
 		compare(t, raw.Bytes(), []byte(tt.raw))
 	}
 

--- a/pkg/pdfcpu/model/dereference.go
+++ b/pkg/pdfcpu/model/dereference.go
@@ -76,7 +76,7 @@ func (xRefTable *XRefTable) indRefToObject(ir *types.IndirectRef, decodeLazy boo
 
 	xRefTable.CurObj = int(ir.ObjectNumber)
 
-	if l, ok := entry.Object.(*types.LazyObjectStreamObject); ok && decodeLazy {
+	if l, ok := entry.Object.(types.LazyObjectStreamObject); ok && decodeLazy {
 		ob, err := l.DecodedObject(context.TODO())
 		if err != nil {
 			return nil, err

--- a/pkg/pdfcpu/model/xreftable.go
+++ b/pkg/pdfcpu/model/xreftable.go
@@ -982,7 +982,7 @@ func (xRefTable *XRefTable) Catalog() (types.Dict, error) {
 		return nil, errors.New("pdfcpu: Catalog: missing root dict")
 	}
 
-	o, err := xRefTable.indRefToObject(xRefTable.Root)
+	o, err := xRefTable.indRefToObject(xRefTable.Root, true)
 	if err != nil || o == nil {
 		return nil, err
 	}
@@ -999,7 +999,7 @@ func (xRefTable *XRefTable) Catalog() (types.Dict, error) {
 
 // EncryptDict returns a pointer to the root object / catalog.
 func (xRefTable *XRefTable) EncryptDict() (types.Dict, error) {
-	o, err := xRefTable.indRefToObject(xRefTable.Encrypt)
+	o, err := xRefTable.indRefToObject(xRefTable.Encrypt, true)
 	if err != nil || o == nil {
 		return nil, err
 	}

--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -2130,7 +2130,7 @@ func dereferencedObject(c context.Context, ctx *model.Context, objNr int) (types
 		}
 
 		entry.Object = o
-	} else if l, ok := entry.Object.(*types.LazyObjectStreamObject); ok {
+	} else if l, ok := entry.Object.(types.LazyObjectStreamObject); ok {
 		o, err := l.DecodedObject(c)
 		if err != nil {
 			return nil, errors.Wrapf(err, "dereferencedObject: problem dereferencing object %d", objNr)

--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -415,34 +415,14 @@ func parseObjectStream(c context.Context, osd *types.ObjectStreamDict) error {
 		offset += osd.FirstObjOffset
 
 		if i > 0 {
-			dstr := string(decodedContent[offsetOld:offset])
-			if log.ReadEnabled() {
-				log.Read.Printf("parseObjectStream: objString = %s\n", dstr)
-			}
-			o, err := compressedObject(c, dstr)
-			if err != nil {
-				return err
-			}
-
-			if log.ReadEnabled() {
-				log.Read.Printf("parseObjectStream: [%d] = obj %s:\n%s\n", i/2-1, objs[i-2], o)
-			}
+			dstr := decodedContent[offsetOld:offset]
+			o := types.NewLazyObjectStreamObject(osd, dstr, compressedObject)
 			objArray = append(objArray, o)
 		}
 
 		if i == len(objs)-2 {
-			dstr := string(decodedContent[offset:])
-			if log.ReadEnabled() {
-				log.Read.Printf("parseObjectStream: objString = %s\n", dstr)
-			}
-			o, err := compressedObject(c, dstr)
-			if err != nil {
-				return err
-			}
-
-			if log.ReadEnabled() {
-				log.Read.Printf("parseObjectStream: [%d] = obj %s:\n%s\n", i/2, objs[i], o)
-			}
+			dstr := decodedContent[offset:]
+			o := types.NewLazyObjectStreamObject(osd, dstr, compressedObject)
 			objArray = append(objArray, o)
 		}
 
@@ -2144,6 +2124,14 @@ func dereferencedObject(c context.Context, ctx *model.Context, objNr int) (types
 		}
 
 		entry.Object = o
+	} else if l, ok := entry.Object.(*types.LazyObjectStreamObject); ok {
+		o, err := l.DecodedObject(c)
+		if err != nil {
+			return nil, errors.Wrapf(err, "dereferencedObject: problem dereferencing object %d", objNr)
+		}
+
+		model.ProcessRefCounts(ctx.XRefTable, o)
+		entry.Object = o
 	}
 
 	return entry.Object, nil
@@ -2752,43 +2740,6 @@ func dereferenceObject(c context.Context, ctx *model.Context, objNr int) error {
 	return nil
 }
 
-func processDictRefCounts(xRefTable *model.XRefTable, d types.Dict) {
-	for _, e := range d {
-		switch o1 := e.(type) {
-		case types.IndirectRef:
-			xRefTable.IncrementRefCount(&o1)
-		case types.Dict:
-			processRefCounts(xRefTable, o1)
-		case types.Array:
-			processRefCounts(xRefTable, o1)
-		}
-	}
-}
-
-func processArrayRefCounts(xRefTable *model.XRefTable, a types.Array) {
-	for _, e := range a {
-		switch o1 := e.(type) {
-		case types.IndirectRef:
-			xRefTable.IncrementRefCount(&o1)
-		case types.Dict:
-			processRefCounts(xRefTable, o1)
-		case types.Array:
-			processRefCounts(xRefTable, o1)
-		}
-	}
-}
-
-func processRefCounts(xRefTable *model.XRefTable, o types.Object) {
-	switch o := o.(type) {
-	case types.Dict:
-		processDictRefCounts(xRefTable, o)
-	case types.StreamDict:
-		processDictRefCounts(xRefTable, o.Dict)
-	case types.Array:
-		processArrayRefCounts(xRefTable, o)
-	}
-}
-
 // Dereferences all objects including compressed objects from object streams.
 func dereferenceObjects(c context.Context, ctx *model.Context) error {
 	if log.ReadEnabled() {
@@ -2822,7 +2773,7 @@ func dereferenceObjects(c context.Context, ctx *model.Context) error {
 			if err := c.Err(); err != nil {
 				return err
 			}
-			processRefCounts(xRefTable, entry.Object)
+			model.ProcessRefCounts(xRefTable, entry.Object)
 		}
 
 	} else {
@@ -2844,7 +2795,7 @@ func dereferenceObjects(c context.Context, ctx *model.Context) error {
 			if err := c.Err(); err != nil {
 				return err
 			}
-			processRefCounts(xRefTable, entry.Object)
+			model.ProcessRefCounts(xRefTable, entry.Object)
 		}
 
 	}

--- a/pkg/pdfcpu/types/streamdict.go
+++ b/pkg/pdfcpu/types/streamdict.go
@@ -116,7 +116,7 @@ type LazyObjectStreamObject struct {
 }
 
 func NewLazyObjectStreamObject(osd *ObjectStreamDict, startOffset, endOffset int, decodeFunc DecodeLazyObjectStreamObjectFunc) Object {
-	return &LazyObjectStreamObject{
+	return LazyObjectStreamObject{
 		osd:         osd,
 		startOffset: startOffset,
 		endOffset:   endOffset,
@@ -125,8 +125,8 @@ func NewLazyObjectStreamObject(osd *ObjectStreamDict, startOffset, endOffset int
 	}
 }
 
-func (l *LazyObjectStreamObject) Clone() Object {
-	return &LazyObjectStreamObject{
+func (l LazyObjectStreamObject) Clone() Object {
+	return LazyObjectStreamObject{
 		osd:         l.osd,
 		startOffset: l.startOffset,
 		endOffset:   l.endOffset,
@@ -137,8 +137,8 @@ func (l *LazyObjectStreamObject) Clone() Object {
 	}
 }
 
-func (l *LazyObjectStreamObject) PDFString() string {
-	data, err := l.getData()
+func (l LazyObjectStreamObject) PDFString() string {
+	data, err := l.GetData()
 	if err != nil {
 		panic(err)
 	}
@@ -146,11 +146,11 @@ func (l *LazyObjectStreamObject) PDFString() string {
 	return string(data)
 }
 
-func (l *LazyObjectStreamObject) String() string {
+func (l LazyObjectStreamObject) String() string {
 	return l.PDFString()
 }
 
-func (l *LazyObjectStreamObject) getData() ([]byte, error) {
+func (l *LazyObjectStreamObject) GetData() ([]byte, error) {
 	if err := l.osd.Decode(); err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func (l *LazyObjectStreamObject) getData() ([]byte, error) {
 
 func (l *LazyObjectStreamObject) DecodedObject(c context.Context) (Object, error) {
 	if l.decodedObject == nil && l.decodedError == nil {
-		data, err := l.getData()
+		data, err := l.GetData()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pdfcpu/writeObjects.go
+++ b/pkg/pdfcpu/writeObjects.go
@@ -673,6 +673,9 @@ func writeObjectGeneric(ctx *model.Context, o types.Object, objNr, genNr int) (e
 	case types.Name:
 		err = writeNameObject(ctx, objNr, genNr, o)
 
+	case *types.LazyObjectStreamObject:
+		err = writeObject(ctx, objNr, genNr, o.PDFString())
+
 	default:
 		err = errors.Errorf("writeIndirectObject: undefined PDF object #%d %T\n", objNr, o)
 	}
@@ -691,7 +694,7 @@ func writeIndirectObject(ctx *model.Context, ir types.IndirectRef) error {
 		return nil
 	}
 
-	o, err := ctx.Dereference(ir)
+	o, err := ctx.DereferenceForWrite(ir)
 	if err != nil {
 		return errors.Wrapf(err, "writeIndirectObject: unable to dereference indirect object #%d", objNr)
 	}

--- a/pkg/pdfcpu/writeObjects.go
+++ b/pkg/pdfcpu/writeObjects.go
@@ -643,6 +643,15 @@ func writeDeepArray(ctx *model.Context, a types.Array, objNr, genNr int) error {
 	return nil
 }
 
+func writeLazyObjectStreamObject(ctx *model.Context, objNr, genNr int, o types.LazyObjectStreamObject) error {
+	data, err := o.GetData()
+	if err != nil {
+		return err
+	}
+
+	return writeObject(ctx, objNr, genNr, string(data))
+}
+
 func writeObjectGeneric(ctx *model.Context, o types.Object, objNr, genNr int) (err error) {
 	switch o := o.(type) {
 
@@ -673,8 +682,8 @@ func writeObjectGeneric(ctx *model.Context, o types.Object, objNr, genNr int) (e
 	case types.Name:
 		err = writeNameObject(ctx, objNr, genNr, o)
 
-	case *types.LazyObjectStreamObject:
-		err = writeObject(ctx, objNr, genNr, o.PDFString())
+	case types.LazyObjectStreamObject:
+		err = writeLazyObjectStreamObject(ctx, objNr, genNr, o)
 
 	default:
 		err = errors.Errorf("writeIndirectObject: undefined PDF object #%d %T\n", objNr, o)


### PR DESCRIPTION
This heavily reduces memory usage for some files.

~~Further improvements could be to only decompress the ObjectStreams when they should actually be parsed.~~ (done)

Fixes #836, see the issue for a testcase / example file.

Before:
```
$ time go run test.go 
2024/03/21 09:03:55.874443 Parsing ...
2024/03/21 09:04:07.947987 Done, uses 4244 MiBytes heap memory, 6755 MiBytes system memory
2024/03/21 09:04:07.948013 Parsed 1133 pages

real	0m12,743s
user	0m21,830s
sys	0m2,589s
```

After:
```
$ time go run test.go 
2024/03/21 09:04:30.639673 Parsing ...
2024/03/21 09:04:30.899588 Done, uses 12 MiBytes heap memory, 11 MiBytes system memory
2024/03/21 09:04:30.899609 Parsed 1133 pages

real	0m0,568s
user	0m0,881s
sys	0m0,228s
```
