### PR TITLE
Ignore errors when parsing optional array of decode parameter dicts

### DIFF
--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -1910,7 +1910,7 @@ func pdfFilterPipeline(c context.Context, ctx *model.Context, dict types.Dict) (
 	decodeParms, found := dict.Find("DecodeParms")
 	if found {
 		decodeParmsArr, ok = decodeParms.(types.Array)
-		if !ok || len(decodeParmsArr) != len(filterArray) {
+		if ok && len(decodeParmsArr) != len(filterArray) {
 			return nil, errors.New("pdfcpu: pdfFilterPipeline: expected decodeParms array corrupt")
 		}
 	}

--- a/pkg/pdfcpu/validate/optionalContent.go
+++ b/pkg/pdfcpu/validate/optionalContent.go
@@ -420,12 +420,11 @@ func validateOCProperties(xRefTable *model.XRefTable, rootDict types.Dict, requi
 
 	// "D" required dict, default viewing optional content configuration dict.
 	d1, err := validateDictEntry(xRefTable, d, dictName, "D", REQUIRED, sinceVersion, nil)
-	if err != nil {
-		return err
-	}
-	err = validateOptionalContentConfigurationDict(xRefTable, d1, sinceVersion)
-	if err != nil {
-		return err
+	if err == nil  {
+		err = validateOptionalContentConfigurationDict(xRefTable, d1, sinceVersion)
+		if err != nil {
+			return err
+		}
 	}
 
 	// "Configs" optional array of alternate optional content configuration dicts.


### PR DESCRIPTION
Fixes #859 

* No longer error when failing to parse optional decode param dicts for pdf filter pipeline
* No longer try to validate above dict when its failed to parse

As noted in the issue, please review the changes I've made as I'm no Go expert, nor PDF expert.