### PR TITLE
Allow to set the PDF Creator with properties command

### DIFF
--- a/pkg/pdfcpu/validate/info.go
+++ b/pkg/pdfcpu/validate/info.go
@@ -28,7 +28,7 @@ import (
 
 // DocumentProperty ensures a property name that may be modified.
 func DocumentProperty(s string) bool {
-	return !types.MemberOf(s, []string{"Keywords", "Creator", "Producer", "CreationDate", "ModDate", "Trapped"})
+	return !types.MemberOf(s, []string{"Keywords", "Producer", "CreationDate", "ModDate", "Trapped"})
 }
 
 func handleDefault(xRefTable *model.XRefTable, o types.Object) (string, error) {


### PR DESCRIPTION
1. Please do not create a Pull Request without creating an issue first.

See #424

2. **Any** change needs to be discussed before proceeding.

Allowing to edit the Creator may be useful e.g. for security to avoid disclosure of used tools or to fix invalid or problematic metadata strings.

3. Please provide enough information for PR review.

Keywords can already be set via pdfcpu keywords, the dates and producer are apparently always set when the document is edited with pdfcpu properties. As far as I could see, `Trapped` should not be modified manually to avoid inconsistencies so just the `Creator` property can now be edited via `pdfcpu properties add` .

Overriding the `CreationDate` and `ModDate` is currently out of scope for this PR. That might also be useful, but require further modifications to the code base (and maybe a `-force` flag or so?).

Author, Subject and Title can already be edited with the current version of `pdfcpu`.

Tested on Debian 11, Debian 12 compiled with go1.22.1

4. Fixes  #424 (except date setting, should we open a new issue for that?)

Thank you very much, best regards
Andreas
