### PR TITLE
[fix] pdfcpu: decodeString: dict=annotDict entry=Contents invalid typ…

### DIFF
--- a/pkg/pdfcpu/validate/object.go
+++ b/pkg/pdfcpu/validate/object.go
@@ -1031,6 +1031,8 @@ func decodeString(o types.Object, dictName, entryName string) (s string, err err
 		s, err = types.StringLiteralToString(o)
 	case types.HexLiteral:
 		s, err = types.HexLiteralToString(o)
+	case types.Integer:
+		return o.String(), nil
 	default:
 		err = errors.Errorf("pdfcpu: decodeString: dict=%s entry=%s invalid type %T", dictName, entryName, o)
 	}


### PR DESCRIPTION
My pull request can resolve this issue: https://github.com/pdfcpu/pdfcpu/issues/886.
I'm not sure if this is the best solution, but making this modification did solve my problem.
The information about my debugging is below 👇
![Screenshot 2024-06-05 at 18 33 05](https://github.com/pdfcpu/pdfcpu/assets/29156418/46eb069f-4549-4525-b1d3-2d734a3c4495)
Due to privacy concerns, I apologize for not being able to submit a test case.
