### PR TITLE
Support IndirectRef entries for Checkbox appearance dict (and its values)

### DIFF
--- a/pkg/pdfcpu/form/fill.go
+++ b/pkg/pdfcpu/form/fill.go
@@ -569,7 +569,7 @@ func fillCheckBoxKid(ctx *model.Context, kids types.Array, off bool) (*types.Nam
 		return nil, errors.New("pdfcpu: corrupt AP field: missing entry N")
 	}
 
-	offName, yesName := primitives.CalcCheckBoxASNames(d2)
+	offName, yesName := primitives.CalcCheckBoxASNames(ctx, d2)
 	asName := yesName
 	if off {
 		asName = offName
@@ -637,7 +637,7 @@ func fillCheckBox(
 
 	d["V"] = v
 	if _, found := d.Find("AS"); found {
-		offName, yesName := primitives.CalcCheckBoxASNames(d)
+		offName, yesName := primitives.CalcCheckBoxASNames(ctx, d)
 		//fmt.Printf("off:<%s> yes:<%s>\n", offName, yesName)
 		asName := yesName
 		if v == "Off" {

--- a/pkg/pdfcpu/model/dereference.go
+++ b/pkg/pdfcpu/model/dereference.go
@@ -468,3 +468,17 @@ func (xRefTable *XRefTable) DestName(obj types.Object) (string, error) {
 
 	return s, err
 }
+
+func (xRefTable *XRefTable) ResolveDictEntry(d types.Dict, key string) types.Dict {
+	value, found := d.Find(key)
+	if !found {
+		return nil
+	}
+
+	d, err := xRefTable.DereferenceDict(value)
+	if err != nil {
+		return nil
+	}
+
+	return d
+}

--- a/pkg/pdfcpu/primitives/checkBox.go
+++ b/pkg/pdfcpu/primitives/checkBox.go
@@ -761,11 +761,11 @@ func (cb *CheckBox) render(p *model.Page, pageNr int, fonts model.FontMap) error
 	return cb.doRender(p, fonts)
 }
 
-func CalcCheckBoxASNames(d types.Dict) (types.Name, types.Name) {
-	apDict := d.DictEntry("AP")
-	d1 := apDict.DictEntry("D")
+func CalcCheckBoxASNames(ctx *model.Context, d types.Dict) (types.Name, types.Name) {
+	apDict := ctx.ResolveDictEntry(d, "AP")
+	d1 := ctx.ResolveDictEntry(apDict, "D")
 	if d1 == nil {
-		d1 = apDict.DictEntry("N")
+		d1 = ctx.ResolveDictEntry(apDict, "N")
 	}
 	offName, yesName := "Off", "Yes"
 	for k := range d1 {

--- a/pkg/pdfcpu/types/dict.go
+++ b/pkg/pdfcpu/types/dict.go
@@ -248,14 +248,13 @@ func (d Dict) IndirectRefEntry(key string) *IndirectRef {
 }
 
 // DictEntry expects and returns a PDFDict entry for given key.
+// Use ctx.ResolveDictEntry(d, key) if you want to resolve IndirectRef entries
 func (d Dict) DictEntry(key string) Dict {
 
 	value, found := d.Find(key)
 	if !found {
 		return nil
 	}
-
-	// TODO resolve indirect ref.
 
 	d, ok := value.(Dict)
 	if ok {


### PR DESCRIPTION
This fixes filling out checkboxes in forms that use non-standard "Yes" states and define their appearance via IndirectRef entries (as seen in some EPO forms).

Here’s an example of a PDF form that requires this fix to render checked checkboxes correctly: https://link.epo.org/web/applying/forms/epo-form-7000-07-24-editable.pdf
(It’s a request form by the European Patent Office for a Unitary Patent.)

Here’s how to repro the issue:
1. `pdfcpu form export epo-form-7000-07-24-editable.pdf`
2. Edit `out.json` and set one or more of the checkbox values to true.
3. `pdfcpu form fill epo-form-7000-07-24-editable.pdf out.json out.pdf`
4. Look at the result. The checkboxes are not rendered as checked.

The reason is that all but the first checkbox store their `AP` dicts as `IndirectRef` (and even the values inside that dict are `IndirectRef` entries), so the old code fails to detect that the `Yes` state is called `Ja` and therefore uses the wrong value when setting the appearance state (`AS`).