### PR TITLE
Check if "entry.Offset" is nil before dereferencing.

### DIFF
--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -644,7 +644,7 @@ func processXRefStream(ctx *model.Context, xsd *types.XRefStreamDict, objNr, gen
 
 	*offset += offExtra
 
-	if entry, ok := ctx.Table[*objNr]; ok && *entry.Offset == *offset {
+	if entry, ok := ctx.Table[*objNr]; ok && entry.Offset != nil && *entry.Offset == *offset {
 		entry.Object = *xsd
 	}
 


### PR DESCRIPTION
Fixes #1009 