### PR TITLE
Bump GitHub actions to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  # Enable version updates for Go modules
+  - package-ecosystem: gomod
+    directory: /
+    # Check for updates to Go modules once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repo      
+        uses: actions/checkout@v3
+
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 
       - run: go version
-
-      - name: Checkout repo      
-        uses: actions/checkout@v3
 
       - name: Go vet
         run: go vet -v ./...


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions. It also fixes warnings as e.g. seen [here](https://github.com/pdfcpu/pdfcpu/actions/runs/12121154268).

```
Restore cache failed: Dependencies file is not found in /home/runner/work/pdfcpu/pdfcpu.
Supported file pattern: go.sum
```