### PR TITLE
solve wkhtmltopdf compatiable, datetime format parser remove special prefix.

### DIFF
--- a/pkg/pdfcpu/types/date.go
+++ b/pkg/pdfcpu/types/date.go
@@ -54,6 +54,10 @@ func prevalidateDate(s string, relaxed bool) (string, bool) {
 	// Remove trailing 0x00
 	s = strings.TrimRight(s, "\x00")
 
+	// Remove "()", dateformat just like (D:20060102150405-07'00')
+	s = strings.TrimPrefix(s, "(")
+	s = strings.TrimSuffix(s, ")")
+
 	if relaxed {
 		// Accept missing "D:" prefix.
 		// "YYYY" is mandatory

--- a/pkg/pdfcpu/types/date_test.go
+++ b/pkg/pdfcpu/types/date_test.go
@@ -154,6 +154,9 @@ func TestParseDateTime(t *testing.T) {
 
 	s = "\357\273\277D:20160404061414+65'53'"
 	doParseDateTimeRelaxedOK(s, t)
+
+	s = "(D:20180114111207+08'00')"
+	doParseDateTimeRelaxedOK(s, t)
 }
 
 func TestWriteDateTime(t *testing.T) {

--- a/pkg/pdfcpu/validate/destination.go
+++ b/pkg/pdfcpu/validate/destination.go
@@ -62,6 +62,11 @@ func validateDestinationArray(xRefTable *model.XRefTable, a types.Array) error {
 		return err
 	}
 
+	// XYZ - 5 elements compatible, in wkhtmltopdf maybe multiple times. look like [0 /XYZ 28.5000000 753.500000 0 0 /XYZ 28.5000000 753.500000 0]
+	if len(a) > 5 && a[1] == types.Name("XYZ") {
+		a = a[:5]
+	}
+
 	if !validateDestinationArrayLength(a) {
 		return errors.Errorf("pdfcpu: validateDestinationArray: invalid length: %d", len(a))
 	}


### PR DESCRIPTION
This PR fixes an issue addressed in #1043.