### PR TITLE
Fix #1058 Use relaxed validation for dict=Square entry=RD

### DIFF
--- a/pkg/pdfcpu/validate/annotation.go
+++ b/pkg/pdfcpu/validate/annotation.go
@@ -672,6 +672,11 @@ func validateAnnotationDictCircleOrSquare(xRefTable *model.XRefTable, d types.Di
 		return err
 	}
 
+	sinceVersion = model.V15
+	if xRefTable.ValidationMode == model.ValidationRelaxed {
+		sinceVersion = model.V14
+	}
+
 	// RD, optional, rectangle, since V1.5
 	_, err = validateRectangleEntry(xRefTable, d, dictName, "RD", OPTIONAL, sinceVersion, nil)
 

--- a/pkg/pdfcpu/validate/annotation.go
+++ b/pkg/pdfcpu/validate/annotation.go
@@ -673,7 +673,7 @@ func validateAnnotationDictCircleOrSquare(xRefTable *model.XRefTable, d types.Di
 	}
 
 	// RD, optional, rectangle, since V1.5
-	_, err = validateRectangleEntry(xRefTable, d, dictName, "RD", OPTIONAL, model.V15, nil)
+	_, err = validateRectangleEntry(xRefTable, d, dictName, "RD", OPTIONAL, sinceVersion, nil)
 
 	return err
 }


### PR DESCRIPTION
Fixes #1058 

We have a PDF (can't share as it contains sensitive info) which while attempting to validate gives `Error dict=Square entry=RD: unsupported in version 1.4`  Library is explicitly validating against version 1.5 for this. 

I went through https://github.com/pdfcpu/pdfcpu/commit/515c2eff91ecbe5a88147133b581bea68c352526 for #437 
and added a similar change here. 
