### PR TITLE
Avoid duplicate keyword search

### DIFF
--- a/pkg/pdfcpu/model/parse.go
+++ b/pkg/pdfcpu/model/parse.go
@@ -1168,7 +1168,7 @@ func posFloor(pos1, pos2 int) int {
 		return pos2
 	}
 	if pos1 < pos2 {
-		return pos2
+		return pos1
 	}
 	if pos2 < 0 {
 		return pos1

--- a/pkg/pdfcpu/model/parse.go
+++ b/pkg/pdfcpu/model/parse.go
@@ -1244,10 +1244,18 @@ func isComment(commentPos, strLitPos int) bool {
 }
 
 func DetectKeywords(line string) (endInd int, streamInd int, err error) {
+	return DetectKeywordsWithContext(context.Background(), line)
+}
+
+func DetectKeywordsWithContext(c context.Context, line string) (endInd int, streamInd int, err error) {
 	// return endInd or streamInd which ever first encountered.
 	off, i := 0, 0
 	strLitPos, commentPos := 0, 0
 	for {
+		if err := c.Err(); err != nil {
+			return -1, -1, err
+		}
+
 		detectMarkers(line, &endInd, &streamInd)
 
 		if off == 0 && endInd < 0 && streamInd < 0 {

--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -1738,7 +1738,7 @@ func buffer(c context.Context, rd io.Reader) (buf []byte, endInd int, streamInd 
 		growSize = min(growSize*2, maximumBufSize)
 		line := string(buf)
 
-		endInd, streamInd, err = model.DetectKeywords(line)
+		endInd, streamInd, err = model.DetectKeywordsWithContext(c, line)
 		if err != nil {
 			return nil, 0, 0, 0, err
 		}


### PR DESCRIPTION
Fixes #1057

The example file contains a huge object with this content:
```
210891 0 obj
<</Limits [(node00000002) (node00275919)]
/Names [(node00000002) 8591 0 R (node00000006) 190838 0 R (node00000007) 66313 0 R (node00000008) 24685 0 R (node00000009) 208328 0 R (node00000010) 163561 0 R (node00000011) 27134 0 R (node00000012) 126131 0 R (node00000013) 9895 0 R (node00000014) 101713 0 R (node00000015) 64243 0 R (node00000016) 118039 0 R (node00000017)
... continues for more than 5 MBytes ...
(node00275919) 209354 0 R]>>
endobj
```

This blows up the parsing code in https://github.com/pdfcpu/pdfcpu/blob/4e0e0db8c786122a8efbe5fb71c070810a4aca1d/pkg/pdfcpu/model/parse.go#L1243
Here the keywords are searched lots of times after the start is advanced for each string literal inside the array (e.g. `(node00000002)`, etc.).

The PR fixes this by searching only once for the keywords and then adjusting the position if strings / comments are found before them. In my tests the example file now parses in about 3 seconds.