### PR TITLE
skip name tree validation on nil entry

### DIFF
--- a/pkg/pdfcpu/validate/nameTree.go
+++ b/pkg/pdfcpu/validate/nameTree.go
@@ -633,14 +633,14 @@ func validateNameTreeDictNamesEntry(xRefTable *model.XRefTable, d types.Dict, na
 
 			continue
 		}
+		if o != nil {
+			err = validateNameTreeValue(name, xRefTable, o)
+			if err != nil {
+				return "", "", err
+			}
 
-		err = validateNameTreeValue(name, xRefTable, o)
-		if err != nil {
-			return "", "", err
+			node.AppendToNames(key, o)
 		}
-
-		node.AppendToNames(key, o)
-
 	}
 
 	return firstKey, lastKey, nil


### PR DESCRIPTION
name tree に null が含まれている場合にエラーとなるため、回避策を入れる
