### PR TITLE
Fix https://github.com/pdfcpu/pdfcpu/issues/1118

### DIFF
--- a/pkg/pdfcpu/types/date.go
+++ b/pkg/pdfcpu/types/date.go
@@ -348,6 +348,12 @@ func DateTime(s string, relaxed bool) (time.Time, bool) {
 
 	var d time.Time
 
+	var err error 
+	s, err = strconv.Unquote("\""+s+"\"")
+	if err != nil {
+		return d, false
+	}
+
 	var ok bool
 	s, ok = prevalidateDate(s, relaxed)
 	if !ok {


### PR DESCRIPTION
This fix error when the ModDate contains escaped characters. There are PDF with this, especially regarding the e-Invoicing reform in France
A pdf containing this and detail log error are attached to this issue: https://github.com/pdfcpu/pdfcpu/issues/1118 
