### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # /data # exit           // exit container
 
 # Start from the latest golang base image
-FROM golang:latest as builder
+FROM golang:latest AS builder
 
 # install
 RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@latest


### PR DESCRIPTION
Fixed an issue brought up by the docker cli during build.

```
1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 25)
```

## Thank you for your contribution!

1. **Please do not create a Pull Request without creating an issue first.**

Sorry, I didn't see this till I had already submitted. It was such a simple fix that I used the github editor which circumvented the normal issue into PR workflow.

3. **Any** change needs to be discussed within the issue before proceeding.

4. Issue discussion will determine further steps like whether a PR is needed or not. 

3. Please provide enough information for PR review.

I ran docker build to build the Dockerfile and the docker cli shot me a warning about AS being lowercase and FROM being uppercase. This change will stop that warning from showing. 

5. Fixes # 1148
