### PR TITLE
protect against uninitialized map in validatePageEntryThumb

### DIFF
--- a/pkg/pdfcpu/validate/page.go
+++ b/pkg/pdfcpu/validate/page.go
@@ -308,8 +308,14 @@ func validatePageEntryThumb(xRefTable *model.XRefTable, d types.Dict, required b
 	}
 
 	indRef := d.IndirectRefEntry("Thumb")
+	//fmt.Printf("adding thumb page:%d obj#:%d %v\n", xRefTable.CurPage, indRef.ObjectNumber.Value(), xRefTable.PageThumbs)
+
+	// Ensure PageThumbs map is initialized
+	if xRefTable.PageThumbs == nil {
+		xRefTable.PageThumbs = map[int]types.IndirectRef{}
+	}
+
 	xRefTable.PageThumbs[xRefTable.CurPage] = *indRef
-	//fmt.Printf("adding thumb page:%d obj#:%d\n", xRefTable.CurPage, indRef.ObjectNumber.Value())
 
 	return nil
 }


### PR DESCRIPTION
The issue was that somewhere in the codebase, an XRefTable instance is being created without using the newXRefTable function that properly initializes all map fields, including PageThumbs. The fix I've provided checks if PageThumbs is nil and initializes it if needed, ensuring that the code can handle cases where the map wasn't properly initialized.

 Fixes # 1149
