### PR TITLE
fix(fill): Prevent Panic When Rectangle is IndirectRef

### DIFF
--- a/pkg/pdfcpu/model/xreftable.go
+++ b/pkg/pdfcpu/model/xreftable.go
@@ -2908,6 +2908,10 @@ func (xRefTable *XRefTable) BindViewerPreferences() {
 
 // RectForArray returns a new rectangle for given Array.
 func (xRefTable *XRefTable) RectForArray(a types.Array) (*types.Rectangle, error) {
+	if len(a) != 4 {
+		return nil, errors.Errorf("pdfcpu: RectForArray: invalid array length %d", len(a))
+	}
+
 	llx, err := xRefTable.DereferenceNumber(a[0])
 	if err != nil {
 		return nil, err

--- a/pkg/pdfcpu/primitives/textField.go
+++ b/pkg/pdfcpu/primitives/textField.go
@@ -913,7 +913,12 @@ func NewTextField(
 	}
 	tf.MaxLen = maxLen
 
-	bb, err := ctx.RectForArray(d.ArrayEntry("Rect"))
+	rect, err := resolveArray(ctx, d, "Rect")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bb, err := ctx.RectForArray(rect)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -946,6 +951,35 @@ func NewTextField(
 	tf.Border = &b
 
 	return tf, fontIndRef, nil
+}
+
+// resolveArray attempts to resolve an array from a dictionary entry. This perform s
+func resolveArray(ctx *model.Context, d types.Dict, key string) (types.Array, error) {
+	rect, found := d.Find(key)
+	if !found {
+		return nil, errors.Errorf("pdfcpu: resolveArray: key not found: key=%s", key)
+	}
+
+	// If it's an array, return it
+	array, ok := rect.(types.Array)
+	if ok {
+		return array, nil
+	}
+
+	// Otherwise, check if it's an indirect reference. If so, dereference it and confirm it's an array.
+	indirectRef, ok := rect.(types.IndirectRef)
+	if ok {
+		rect, err := ctx.Dereference(indirectRef)
+		if err != nil {
+			return nil, err
+		}
+		rectArray, ok := rect.(types.Array)
+		if ok {
+			return rectArray, nil
+		}
+	}
+
+	return nil, errors.Errorf("failed to resolve array: key=%s", key)
 }
 
 func renderTextFieldAP(ctx *model.Context, d types.Dict, v string, multiLine, comb bool, maxLen int, da *string, fonts map[string]types.IndirectRef) error {


### PR DESCRIPTION
Fixes #1189. This prevents a panic if a form field rectangle is an IndirectRef.

We haven't discussed this change in the issue yet but found success locally. If this change is unwanted, I'll be sure to close :) 
