### PR TITLE
Fix #1226: Correct typo in calcBorder()

### DIFF
--- a/pkg/pdfcpu/primitives/content.go
+++ b/pkg/pdfcpu/primitives/content.go
@@ -728,7 +728,7 @@ func (c *Content) calcBorder(bb map[string]*Border) {
 	if c.Regions != nil {
 		if c.Regions.horizontal {
 			c.Regions.Left.calcBorder(bbb)
-			c.Regions.Right.calcBorder(bb)
+			c.Regions.Right.calcBorder(bbb)
 		} else {
 			c.Regions.Top.calcBorder(bbb)
 			c.Regions.Bottom.calcBorder(bbb)


### PR DESCRIPTION
## Summary
- Fixed typo in `calcBorder()` where `Right` region was incorrectly passed `bb` instead of `bbb`
- This aligns with the pattern used in `calcMargin()` and `calcPadding()` functions
- Ensures Right border receives merged border configuration consistently with Left, Top, and Bottom

## Test plan
- Existing tests should pass
- The fix ensures consistent border handling across all regions

Fixes #1226