### PR TITLE
Fix #1229: Handle choice fields with missing Opt entry

### DIFF
--- a/pkg/pdfcpu/form/export.go
+++ b/pkg/pdfcpu/form/export.go
@@ -374,15 +374,13 @@ func extractComboBox(xRefTable *model.XRefTable, page int, d types.Dict, id, nam
 		cb.Value = strings.TrimSpace(s)
 	}
 
-	opts, err := parseOptions(xRefTable, d, REQUIRED)
+	opts, err := parseOptions(xRefTable, d, OPTIONAL)
 	if err != nil {
 		return nil, err
 	}
-	if len(opts) == 0 {
-		return nil, errors.New("pdfcpu: combobox missing Opts")
+	if opts != nil {
+		cb.Options = opts
 	}
-
-	cb.Options = opts
 
 	return cb, nil
 }
@@ -534,15 +532,13 @@ func extractListBox(xRefTable *model.XRefTable, page int, d types.Dict, id, name
 		lb.Values = ss
 	}
 
-	opts, err := parseOptions(xRefTable, d, REQUIRED)
+	opts, err := parseOptions(xRefTable, d, OPTIONAL)
 	if err != nil {
 		return nil, err
 	}
-	if len(opts) == 0 {
-		return nil, errors.New("pdfcpu: listbox missing Opts")
+	if opts != nil {
+		lb.Options = opts
 	}
-
-	lb.Options = opts
 
 	return lb, nil
 }

--- a/pkg/pdfcpu/form/fill.go
+++ b/pkg/pdfcpu/form/fill.go
@@ -881,13 +881,14 @@ func fillCh(
 		return errors.New("pdfcpu: corrupt form field: missing entry Ff")
 	}
 
-	opts, err := parseOptions(ctx.XRefTable, d, REQUIRED)
+	opts, err := parseOptions(ctx.XRefTable, d, OPTIONAL)
 	if err != nil {
 		return err
 	}
 
-	if len(opts) == 0 {
-		return errors.New("pdfcpu: missing Opts")
+	if opts == nil || len(opts) == 0 {
+		// No options to fill, skip this field
+		return nil
 	}
 
 	if primitives.FieldFlags(*ff)&primitives.FieldCombo > 0 {

--- a/pkg/pdfcpu/form/form.go
+++ b/pkg/pdfcpu/form/form.go
@@ -508,14 +508,16 @@ func collectListBox(xRefTable *model.XRefTable, multi bool, d types.Dict, f *Fie
 func collectCh(xRefTable *model.XRefTable, d types.Dict, f *Field, fm *FieldMeta) error {
 	ff := d.IntEntry("Ff")
 
-	vv, err := parseOptions(xRefTable, d, REQUIRED)
+	vv, err := parseOptions(xRefTable, d, OPTIONAL)
 	if err != nil {
 		return err
 	}
 
-	f.Opts = strings.Join(vv, ",")
-	if len(f.Opts) > 0 {
-		fm.opt = true
+	if vv != nil {
+		f.Opts = strings.Join(vv, ",")
+		if len(f.Opts) > 0 {
+			fm.opt = true
+		}
 	}
 
 	if ff != nil && primitives.FieldFlags(*ff)&primitives.FieldCombo > 0 {
@@ -1452,12 +1454,15 @@ func resetCh(ctx *model.Context, d types.Dict, fonts map[string]types.IndirectRe
 		return errors.New("pdfcpu: corrupt form field: missing entry \"Ff\"")
 	}
 
-	opts, err := parseOptions(ctx.XRefTable, d, REQUIRED)
+	opts, err := parseOptions(ctx.XRefTable, d, OPTIONAL)
 	if err != nil {
 		return err
 	}
-	if len(opts) == 0 {
-		return errors.New("pdfcpu: missing Opts")
+	if opts == nil || len(opts) == 0 {
+		// No options to reset to, clear any existing values
+		d.Delete("I")
+		d.Delete("V")
+		return nil
 	}
 
 	var ind types.Array


### PR DESCRIPTION
## Summary

Fixes #1229 by making the `Opt` entry optional for choice fields (ListBox and ComboBox), allowing pdfcpu to gracefully handle PDFs created by Adobe Acrobat that contain choice fields with no options.

## Problem

Adobe Acrobat allows creating ListBox and ComboBox fields with zero options, which results in PDFs without an `Opt` entry in the field dictionary. Previously, pdfcpu would fail with the error:

```
corrupt form field: missing entry "Opt"
```

This prevented users from listing, exporting, or processing such PDFs, even though they are valid according to the PDF specification (which marks `Opt` as optional).

## Solution

Changed all `parseOptions` calls from `REQUIRED` to `OPTIONAL` in:
- `pkg/pdfcpu/form/form.go` - `collectCh()` and `resetCh()` functions
- `pkg/pdfcpu/form/export.go` - `extractComboBox()` and `extractListBox()` functions  
- `pkg/pdfcpu/form/fill.go` - `fillChoiceField()` function

Each function now handles missing or empty options gracefully:
- **collectCh**: Skips setting options if none are present
- **resetCh**: Clears any existing values if no options available
- **export functions**: Exports fields with empty options array
- **fill functions**: Skips filling if no options available

## Testing

Tested with the provided `LISTBOX.pdf` file from the issue:

```
$ ./pdfcpu form list LISTBOX.pdf
/tmp/LISTBOX.pdf:

Pg L Field     │ Id  │ Name      
━━━━━━━━━━━━━━━┿━━━━━┿━━━━━━━━━━━
1    ListBox   │ 24  │ List Box1
```

The command now successfully lists the ListBox field without errors.

## Impact

This change improves compatibility with real-world PDF files created by Adobe Acrobat and follows the PDF specification's guidance that the `Opt` entry is optional for choice fields.