### PR TITLE
Fix #1179: Make WriteContext deterministic by sorting dictionary keys

### DIFF
--- a/pkg/pdfcpu/crypto.go
+++ b/pkg/pdfcpu/crypto.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"sort"
 	"strconv"
 	"time"
 
@@ -1679,7 +1680,14 @@ func fileID(ctx *model.Context) (types.HexLiteral, error) {
 		if err != nil {
 			return "", err
 		}
-		for _, v := range d {
+		var keys []string
+		for k := range d {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := d[k]
 			o, err := ctx.Dereference(v)
 			if err != nil {
 				return "", err

--- a/pkg/pdfcpu/writeObjects.go
+++ b/pkg/pdfcpu/writeObjects.go
@@ -18,6 +18,7 @@ package pdfcpu
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/pdfcpu/pdfcpu/pkg/log"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
@@ -518,7 +519,14 @@ func writeDirectObject(ctx *model.Context, o types.Object) error {
 	switch o := o.(type) {
 
 	case types.Dict:
-		for k, v := range o {
+		var keys []string
+		for k := range o {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := o[k]
 			if ctx.WritingPages && (k == "Dest" || k == "D") {
 				ctx.Dest = true
 			}
@@ -580,7 +588,14 @@ func writeDeepDict(ctx *model.Context, d types.Dict, objNr, genNr int) error {
 		return err
 	}
 
-	for k, v := range d {
+	var keys []string
+	for k := range d {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := d[k]
 		if ctx.WritingPages && (k == "Dest" || k == "D") {
 			ctx.Dest = true
 		}
@@ -604,7 +619,14 @@ func writeDeepStreamDict(ctx *model.Context, sd *types.StreamDict, objNr, genNr 
 		return err
 	}
 
-	for _, v := range sd.Dict {
+	var keys []string
+	for k := range sd.Dict {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := sd.Dict[k]
 		if _, _, err := writeDeepObject(ctx, v); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

This PR fixes issue #1179 by making `api.WriteContext` produce deterministic output when called on the same `*model.Context`.

## Problem

The issue reported that calling `api.WriteContext` twice on the same context produced different binary output. The maintainer correctly identified that this was due to Go's intentionally randomized map iteration order.

When writing PDF objects, the code would iterate over dictionary entries in random order, causing child objects to be written at different file offsets on each run. This resulted in different XRef tables and overall different binary output, even though the PDFs were semantically identical.

## Solution

Sort dictionary keys before iterating over them in all write path functions:

1. **pkg/pdfcpu/writeObjects.go**:
   - `writeDirectObject()`: Sort keys before writing child objects
   - `writeDeepDict()`: Sort keys before writing child objects
   - `writeDeepStreamDict()`: Sort keys before writing child objects

2. **pkg/pdfcpu/crypto.go**:
   - `fileID()`: Sort keys when computing file ID hash

## Testing

- All existing tests pass
- Verified merge and optimize functionality still works correctly
- The changes maintain the same PDF structure, just in a deterministic order

## Notes

This fix addresses the dictionary iteration order issue. Full determinism also requires users to:
- Set fixed document IDs (as the issue reporter plans to do)
- Control timestamp generation in the document info dictionary

These are separate concerns that can be handled at the application level, as shown in the issue.

## PDF Spec Compliance

The PDF specification does not require any particular ordering of dictionary entries or objects, so this change maintains full spec compliance while improving determinism.

Fixes #1179