### PR TITLE
Fix PDF 1.4 version check in parseTrailerDict

### DIFF
--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -1020,7 +1020,7 @@ func parseTrailerDict(c context.Context, ctx *model.Context, trailerDict types.D
 	offsetXRefStream := trailerDict.Int64Entry("XRefStm")
 	if offsetXRefStream == nil || repairing {
 		// No cross reference stream.
-		if !ctx.Reader15 && xRefTable.Version() >= model.V14 && !ctx.Read.Hybrid {
+		if !ctx.Reader15 && xRefTable.Version() >= model.V15 && !ctx.Read.Hybrid {
 			return nil, errors.Errorf("parseTrailerDict: PDF1.4 conformant reader: found incompatible version: %s", xRefTable.VersionString())
 		}
 		if log.ReadEnabled() {


### PR DESCRIPTION
## Summary
- Fixes incorrect PDF version check that was rejecting valid PDF 1.4 files
- Changes version comparison from `>= V14` to `>= V15` in parseTrailerDict

## Problem
When `Reader15=false` (PDF 1.4 conformant mode), the reader was incorrectly rejecting PDF 1.4 and 1.7 files with the error:
```
PDF1.4 conformant reader: found incompatible version: 1.4
```

This occurred because:
1. Users creating custom `Configuration` objects without setting `Reader15` would get `false` as the default (zero value)
2. The buggy version check rejected any PDF >= 1.4 instead of >= 1.5

## Root Cause
According to PDF specification:
- PDF 1.4 and earlier: Use cross-reference tables
- PDF 1.5+: Introduced cross-reference streams

The code at `pkg/pdfcpu/read.go:1023` was checking `>= model.V14` when it should check `>= model.V15`.

When `Reader15=false`, the reader should:
- ✅ Accept PDF 1.0-1.4 (traditional cross-reference tables)
- ❌ Reject PDF 1.5+ (may require cross-reference stream support)

The bug made it reject PDF 1.4 files in PDF 1.4 mode, which is incorrect.

## Changes
- `pkg/pdfcpu/read.go:1023`: Changed `model.V14` to `model.V15`

## Testing
- All existing tests pass
- Fixes the issue reported in #846

Fixes #846