### PR TITLE
Fix #779: Make CIDSet and FontFile2 optional in fontDescriptorIndRefs

### DIFF
--- a/pkg/pdfcpu/font/fontDict.go
+++ b/pkg/pdfcpu/font/fontDict.go
@@ -85,15 +85,13 @@ func fontDescriptorIndRefs(fd types.Dict, lang string, font *model.FontResource)
 		}
 	}
 
+	// CIDSet is optional per ISO 32000 (only required for PDF/A-1).
+	// If nil, UpdateUserfont will create a new one.
 	font.CIDSet = fd.IndirectRefEntry("CIDSet")
-	if font.CIDSet == nil {
-		return ErrCorruptFontDict
-	}
 
+	// FontFile2 is optional per ISO 32000 (font might not be embedded).
+	// If nil, UpdateUserfont will create and embed a new font file.
 	font.FontFile = fd.IndirectRefEntry("FontFile2")
-	if font.FontFile == nil {
-		return ErrCorruptFontDict
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes #779 by making CIDSet and FontFile2 optional in the fontDescriptorIndRefs function.

## Problem

The fontDescriptorIndRefs function was incorrectly treating CIDSet and FontFile2 as required fields, causing `ErrCorruptFontDict` when filling forms with Japanese fonts (like IPAmjMincho or IPAexMincho) that have existing embedded fonts.

## Root Cause

According to the PDF ISO 32000 specification:
- **CIDSet** is optional (only required for PDF/A-1 compliance)
- **FontFile2** is optional (font might not be embedded)

The code was incorrectly returning an error when these optional fields were missing.

## Solution

Modified `fontDescriptorIndRefs` to:
1. Allow CIDSet to be nil (optional per ISO 32000)
2. Allow FontFile2 to be nil (optional per ISO 32000)

When these fields are nil, the `UpdateUserfont` function will create new objects as needed, which is the correct behavior:
- `ttfSubFontFile` handles nil indRef by creating a new font file
- `CIDSet` handles nil indRef by creating a new CIDSet

## Testing

- All existing form tests pass
- Build succeeds without errors
- The fix follows the PDF specification requirements

## Related Issue

Closes #779