### PR TITLE
Fix parsing of empty PDF name objects

### DIFF
--- a/pkg/pdfcpu/model/parse.go
+++ b/pkg/pdfcpu/model/parse.go
@@ -512,7 +512,7 @@ func parseName(line *string) (*types.Name, error) {
 	if log.ParseEnabled() {
 		log.Parse.Printf("parseNameObject: %s\n", l)
 	}
-	if len(l) < 2 || !strings.HasPrefix(l, "/") {
+	if !strings.HasPrefix(l, "/") {
 		return nil, errNameObjectCorrupt
 	}
 

--- a/pkg/pdfcpu/model/parse_common_test.go
+++ b/pkg/pdfcpu/model/parse_common_test.go
@@ -66,7 +66,8 @@ func TestParseObject(t *testing.T) {
 	doTestParseObjectOK("/Na#20me", t)
 	doTestParseObjectOK("[null]abc", t)
 
-	doTestParseObjectFail("/", t)
+	// Empty names are valid according to PDF spec ISO 32000-1:2008 Section 7.3.5
+	doTestParseObjectOK("/", t)
 	doTestParseObjectOK("/(", t)
 	doTestParseObjectOK("//", t)
 	doTestParseObjectOK("/abc/", t)

--- a/pkg/pdfcpu/model/parse_test.go
+++ b/pkg/pdfcpu/model/parse_test.go
@@ -118,3 +118,32 @@ func TestDetectKeywords(t *testing.T) {
 	}
 
 }
+
+func TestParseEmptyName(t *testing.T) {
+	// Test parsing empty name (bare "/")
+	// According to PDF spec ISO 32000-1:2008 Section 7.3.5, empty names are valid
+	testcases := []struct {
+		input    string
+		expected string
+		rest     string
+	}{
+		{"/", "", ""},
+		{"/ ", "", " "},
+		{"/<<", "", "<<"},
+		{"/>>/Type", "", ">>/Type"},
+	}
+	for _, tc := range testcases {
+		line := tc.input
+		nameObj, err := parseName(&line)
+		if err != nil {
+			t.Errorf("parsing %q failed: %v", tc.input, err)
+			continue
+		}
+		if string(*nameObj) != tc.expected {
+			t.Errorf("parsing %q: expected name %q, got %q", tc.input, tc.expected, string(*nameObj))
+		}
+		if line != tc.rest {
+			t.Errorf("parsing %q: expected rest %q, got %q", tc.input, tc.rest, line)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #642

## Summary
Empty name objects (a bare `/` character) are valid according to the PDF specification (ISO 32000-1:2008, Section 7.3.5), but were being incorrectly rejected by the `parseName` function in `pkg/pdfcpu/model/parse.go`.

## Root Cause
The `parseName` function had a check `if len(l) < 2` that required at least 2 characters, preventing parsing of empty names (which are just `/` followed by a delimiter or whitespace). This caused the parser to fail with "corrupt name object" error when encountering valid PDFs containing empty names.

## Changes
- **pkg/pdfcpu/model/parse.go**: Removed the `len(l) < 2` check on line 515, keeping only the check for the `/` prefix
- **pkg/pdfcpu/model/parse_test.go**: Added `TestParseEmptyName` with test cases for various empty name scenarios
- **pkg/pdfcpu/model/parse_common_test.go**: Updated the test for `/` from expecting failure to expecting success, with a comment referencing the PDF spec

## Test Results
All model tests pass, including the new test cases for empty names:
```
=== RUN   TestParseEmptyName
--- PASS: TestParseEmptyName (0.00s)
PASS
ok      github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model       0.004s
```

## PDF Specification Reference
According to ISO 32000-1:2008, Section 7.3.5 (Name Objects):
> "Beginning with PDF 1.2 a name object is an atomic symbol uniquely defined by a sequence of any characters (8-bit values) except null (character code 0). When writing a name in a PDF file, a SOLIDUS (2Fh) (/) is used as a prefix to introduce a name."

The specification does not require the sequence to be non-empty, making `/` a valid name object representing an empty name.