### PR TITLE
Fix #399: Handle invalid XRef stream with W array [0 0 0]

### DIFF
--- a/pkg/pdfcpu/read.go
+++ b/pkg/pdfcpu/read.go
@@ -590,7 +590,11 @@ func extractXRefTableEntriesFromXRefStream(buf []byte, offExtra int64, xsd *type
 		log.Read.Printf("extractXRefTableEntriesFromXRefStream: begin xrefEntryLen = %d\n", xrefEntryLen)
 	}
 
-	if xrefEntryLen != 0 && len(buf)%xrefEntryLen > 0 {
+	if xrefEntryLen == 0 {
+		return errors.New("pdfcpu: extractXRefTableEntriesFromXRefStream: invalid W array - all values are zero")
+	}
+
+	if len(buf)%xrefEntryLen > 0 {
 		return errors.New("pdfcpu: extractXRefTableEntriesFromXRefStream: corrupt xrefstream")
 	}
 


### PR DESCRIPTION
## Summary

Fixes #399 - Prevents panic when validating PDFs with malformed XRef streams that have `W: [0 0 0]`.

## Changes

- Added validation check in `extractXRefTableEntriesFromXRefStream` to detect when all W array values are zero
- Returns a descriptive error instead of causing infinite loop or panic
- Simplified the subsequent modulo check since we now guarantee `xrefEntryLen != 0`

## Root Cause

When the W array in an XRef stream dictionary contains all zeros (`[0 0 0]`), the calculated `xrefEntryLen` becomes 0. This caused:
1. The loop at line 619 (`i += xrefEntryLen`) to never increment, creating an infinite loop
2. Potential divide-by-zero errors in validation checks

According to PDF spec, individual zero values in the W array indicate absent fields with defaults, but having all three values as zero results in 0-byte entries which is invalid.

## Testing

- All existing tests pass
- The fix properly validates and rejects malformed PDFs with `W: [0 0 0]` instead of panicking