### PR TITLE
fix: normalize StreamDict AP/N to Dict

### DIFF
--- a/pkg/pdfcpu/form/export.go
+++ b/pkg/pdfcpu/form/export.go
@@ -221,9 +221,18 @@ func locateAPN(xRefTable *model.XRefTable, d types.Dict) (types.Dict, error) {
 	if !ok {
 		return nil, errors.New("corrupt AP field: missing entry \"N\"")
 	}
-	d2, err := xRefTable.DereferenceDict(obj)
+
+	obj, err = xRefTable.Dereference(obj)
 	if err != nil {
 		return nil, err
+	}
+
+	var d2 types.Dict
+	switch o := obj.(type) {
+	case types.Dict:
+		d2 = o
+	case types.StreamDict:
+		d2 = o.Dict
 	}
 
 	if len(d2) == 0 {


### PR DESCRIPTION
Fixes #1289

This PR is an attempt to resolve the linked issue by normalizing `StreamDict` to `Dict` when it is encountered inside the `locateAPN` method, rather than erroring out.

With my limited knowledge of the PDF format, I'm not 100% confident that this is a good solution, but it seemed to work during my testing.