### PR TITLE
Include all packages in coverage with -coverpkg, raises coverage from 4.8% back to 62.3%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest'
-        run: go test -v -coverprofile=coverage.out ./...
+        run: go test -v -coverprofile=coverage.out -coverpkg=./... ./...
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Without `-coverpkg=./...`, coverage is only counted for the package containing the test file. This excluded 15 packages that have no internal tests and are only exercised by the integration tests in `pkg/api/test/` and `pkg/cli/test/`:

```
  pkg/cli, pkg/pdfcpu/validate, pkg/pdfcpu/primitives,
  pkg/pdfcpu/form, pkg/pdfcpu/create, pkg/pdfcpu/sign,
  pkg/pdfcpu/font, pkg/pdfcpu/color, pkg/pdfcpu/draw,
  pkg/pdfcpu/format, pkg/pdfcpu/matrix, pkg/pdfcpu/scan,
  pkg/font, internal/corefont/metrics, cmd/pdfcpu
```

[The problem build on `master](https://coveralls.io/builds/77217709) :
<img width="370" height="132" alt="image" src="https://github.com/user-attachments/assets/3dce58b5-d298-44ff-9265-fd725d24ae8a" />

[Corrected build with 62.3%](https://coveralls.io/builds/77241139)

For #1310

_(I am assuming a separate issue is unnecessary for this minor fixup)_