### PR TITLE
log: use stderr, not stdout

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -157,7 +157,7 @@ func SetDefaultWriteLogger() {
 
 // SetDefaultCLILogger sets the default cli logger.
 func SetDefaultCLILogger() {
-	SetCLILogger(log.New(os.Stdout, "", 0))
+	SetCLILogger(log.New(os.Stderr, "", 0))
 }
 
 // SetDefaultLoggers sets all loggers to their default logger.


### PR DESCRIPTION
pdfcpu CLI can output valid JSON and diagnostics on the same channel, which hampers downstream processing; log to stderr instead

refs #1327 
