### PR TITLE
Fix stack overflow in EqualObjects when comparing circular references

### DIFF
--- a/pkg/api/test/api_test.go
+++ b/pkg/api/test/api_test.go
@@ -198,6 +198,24 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+// TestValidateCircularReference tests that the validate command handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal PDF with
+// circular references in Resources dictionaries that previously could cause infinite recursion
+// in EqualObjects when fixInfoDict compares Metadata and Info dicts.
+func TestValidateCircularReference(t *testing.T) {
+	msg := "TestValidateCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, validation could cause infinite
+	// recursion when comparing objects during fixInfoDict.
+	if err := api.ValidateFile(inFile, nil); err != nil {
+		t.Fatalf("%s: validate should handle circular references without stack overflow: %v\n", msg, err)
+	}
+}
+
 func TestManipulateContext(t *testing.T) {
 	msg := "TestManipulateContext"
 	inFile := filepath.Join(inDir, "5116.DCT_Filter.pdf")

--- a/pkg/api/test/createFromJSON_test.go
+++ b/pkg/api/test/createFromJSON_test.go
@@ -355,3 +355,31 @@ func TestReadFormAndUpdateFormViaJson(t *testing.T) {
 	outFile = filepath.Join(outDir, "readFormAndUpdateFormCJK.pdf")
 	createPDF(t, "pass1", inFile, inFileJSON, outFile, conf)
 }
+
+// TestCreateCircularReference tests that the create command handles PDFs with circular
+// object references without causing a stack overflow when appending content. This test uses
+// a minimal PDF with circular references in Resources dictionaries that previously could
+// cause infinite recursion in EqualObjects when ImageBox compares image stream dicts.
+func TestCreateCircularReference(t *testing.T) {
+	msg := "TestCreateCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	
+	// Use a simple JSON that creates a page with text
+	inFileJSON := filepath.Join(inDir, "json", "create", "textAnchored.json")
+	outFile := filepath.Join(outDir, "circular_ref_created.pdf")
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, creating/appending to this PDF
+	// could cause infinite recursion when comparing objects during ImageBox
+	// image deduplication or other object comparisons.
+	if err := api.CreateFile(inFile, inFileJSON, outFile, nil); err != nil {
+		t.Fatalf("%s: create should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Validate the output
+	if err := api.ValidateFile(outFile, nil); err != nil {
+		t.Fatalf("%s: created PDF should be valid: %v\n", msg, err)
+	}
+}

--- a/pkg/api/test/optimize_test.go
+++ b/pkg/api/test/optimize_test.go
@@ -41,3 +41,26 @@ func TestOptimize(t *testing.T) {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 }
+
+// TestOptimizeCircularReference tests that optimize handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal
+// PDF with circular references in Resources dictionaries that previously caused
+// infinite recursion in EqualObjects.
+func TestOptimizeCircularReference(t *testing.T) {
+	msg := "TestOptimizeCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	outFile := filepath.Join(outDir, fileName)
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, this causes infinite recursion.
+	if err := api.OptimizeFile(inFile, outFile, nil); err != nil {
+		t.Fatalf("%s: optimize should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Test that we can optimize it again (in-place)
+	if err := api.OptimizeFile(outFile, "", nil); err != nil {
+		t.Fatalf("%s: second optimize should also succeed: %v\n", msg, err)
+	}
+}

--- a/pkg/api/test/stamp_test.go
+++ b/pkg/api/test/stamp_test.go
@@ -637,3 +637,32 @@ func TestRecycleWM(t *testing.T) {
 		t.Fatalf("%s %s: %v\n", msg, outFile, err)
 	}
 }
+
+// TestWatermarkCircularReference tests that watermark processing handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal PDF with
+// circular references in Resources dictionaries that previously caused infinite recursion
+// in EqualObjects when watermark processing optimized Form XObjects.
+func TestWatermarkCircularReference(t *testing.T) {
+	msg := "TestWatermarkCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	outFile := filepath.Join(outDir, "circular_ref_watermarked.pdf")
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, watermark processing would cause
+	// infinite recursion when comparing Form XObjects during optimization.
+	if err := api.AddTextWatermarksFile(inFile, outFile, nil, false, "Test", "", nil); err != nil {
+		t.Fatalf("%s: watermark should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Validate the output
+	if err := api.ValidateFile(outFile, nil); err != nil {
+		t.Fatalf("%s: watermarked PDF should be valid: %v\n", msg, err)
+	}
+
+	// Test that we can add another watermark (in-place)
+	if err := api.AddTextWatermarksFile(outFile, "", nil, false, "Second", "", nil); err != nil {
+		t.Fatalf("%s: second watermark should also succeed: %v\n", msg, err)
+	}
+}

--- a/pkg/cli/test/cli_test.go
+++ b/pkg/cli/test/cli_test.go
@@ -149,6 +149,24 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+// TestValidateCircularReference tests that the validate CLI command handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal PDF with
+// circular references in Resources dictionaries that previously could cause infinite recursion
+// in EqualObjects when fixInfoDict compares Metadata and Info dicts.
+func TestValidateCircularReference(t *testing.T) {
+	msg := "TestValidateCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, validation could cause infinite
+	// recursion when comparing objects during fixInfoDict.
+	if err := validateFile(t, inFile, conf); err != nil {
+		t.Fatalf("%s: validate should handle circular references without stack overflow: %v\n", msg, err)
+	}
+}
+
 func TestInfoCommand(t *testing.T) {
 	msg := "TestInfoCommand"
 	inFile := filepath.Join(inDir, "5116.DCT_Filter.pdf")

--- a/pkg/cli/test/createFromJSON_test.go
+++ b/pkg/cli/test/createFromJSON_test.go
@@ -79,3 +79,32 @@ func TestCreateSinglePageDemoFormsViaJson(t *testing.T) {
 
 	// For more comprehensive PDF creation tests please refer to api/test/createFromJSON_test.go
 }
+
+// TestCreateCircularReference tests that the create CLI command handles PDFs with circular
+// object references without causing a stack overflow when appending content. This test uses
+// a minimal PDF with circular references in Resources dictionaries that previously could
+// cause infinite recursion in EqualObjects when ImageBox compares image stream dicts.
+func TestCreateCircularReference(t *testing.T) {
+	msg := "TestCreateCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	
+	// Use a simple JSON that creates a page with text
+	inFileJSON := filepath.Join(inDir, "json", "create", "textAnchored.json")
+	outFile := filepath.Join(outDir, "circular_ref_created.pdf")
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, creating/appending to this PDF
+	// could cause infinite recursion when comparing objects during ImageBox
+	// image deduplication or other object comparisons.
+	cmd := cli.CreateCommand(inFile, inFileJSON, outFile, conf)
+	if _, err := cli.Process(cmd); err != nil {
+		t.Fatalf("%s: create should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Validate the output
+	if err := validateFile(t, outFile, conf); err != nil {
+		t.Fatalf("%s: created PDF should be valid: %v\n", msg, err)
+	}
+}

--- a/pkg/cli/test/optimize_test.go
+++ b/pkg/cli/test/optimize_test.go
@@ -60,3 +60,28 @@ func TestOptimizeCommand(t *testing.T) {
 		testOptimizeFile(t, inFile, outFile)
 	}
 }
+
+// TestOptimizeCircularReference tests that the optimize CLI command handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal PDF with
+// circular references in Resources dictionaries that previously caused infinite recursion
+// in EqualObjects.
+func TestOptimizeCircularReference(t *testing.T) {
+	msg := "TestOptimizeCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	outFile := filepath.Join(outDir, fileName)
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, this causes infinite recursion.
+	cmd := cli.OptimizeCommand(inFile, outFile, conf)
+	if _, err := cli.Process(cmd); err != nil {
+		t.Fatalf("%s: optimize should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Test that we can optimize it again (in-place)
+	cmd = cli.OptimizeCommand(outFile, "", conf)
+	if _, err := cli.Process(cmd); err != nil {
+		t.Fatalf("%s: second optimize should also succeed: %v\n", msg, err)
+	}
+}

--- a/pkg/cli/test/stamp_test.go
+++ b/pkg/cli/test/stamp_test.go
@@ -200,3 +200,44 @@ func TestStampingLifecycle(t *testing.T) {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 }
+
+// TestWatermarkCircularReference tests that the watermark CLI command handles PDFs with circular
+// object references without causing a stack overflow. This test uses a minimal PDF with
+// circular references in Resources dictionaries that previously caused infinite recursion
+// in EqualObjects when watermark processing optimized Form XObjects.
+func TestWatermarkCircularReference(t *testing.T) {
+	msg := "TestWatermarkCircularReference"
+	fileName := "circular_ref_test.pdf"
+	inFile := filepath.Join(inDir, fileName)
+	outFile := filepath.Join(outDir, "circular_ref_watermarked.pdf")
+
+	// This PDF has two Form XObjects with identical stream lengths that
+	// reference each other in their Resources via ProcSet, creating a cycle.
+	// Without cycle detection in EqualObjects, watermark processing would cause
+	// infinite recursion when comparing Form XObjects during optimization.
+	wm, err := pdfcpu.ParseTextWatermarkDetails("Test", "", false, types.POINTS)
+	if err != nil {
+		t.Fatalf("%s: ParseTextWatermarkDetails: %v\n", msg, err)
+	}
+
+	cmd := cli.AddWatermarksCommand(inFile, outFile, nil, wm, conf)
+	if _, err := cli.Process(cmd); err != nil {
+		t.Fatalf("%s: watermark should handle circular references without stack overflow: %v\n", msg, err)
+	}
+
+	// Validate the output
+	if err := validateFile(t, outFile, conf); err != nil {
+		t.Fatalf("%s: watermarked PDF should be valid: %v\n", msg, err)
+	}
+
+	// Test that we can add another watermark (in-place)
+	wm2, err := pdfcpu.ParseTextWatermarkDetails("Second", "", false, types.POINTS)
+	if err != nil {
+		t.Fatalf("%s: ParseTextWatermarkDetails (second): %v\n", msg, err)
+	}
+
+	cmd = cli.AddWatermarksCommand(outFile, "", nil, wm2, conf)
+	if _, err := cli.Process(cmd); err != nil {
+		t.Fatalf("%s: second watermark should also succeed: %v\n", msg, err)
+	}
+}

--- a/pkg/pdfcpu/model/equal.go
+++ b/pkg/pdfcpu/model/equal.go
@@ -18,20 +18,55 @@ package model
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
+	"unsafe"
 
 	"github.com/pkg/errors"
 
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 )
 
+// comparisonKey is used to track object pairs being compared to detect cycles.
+// Uses object numbers for indirect refs, pointer addresses for direct objects.
+type comparisonKey struct {
+	id1 uintptr
+	id2 uintptr
+}
+
+// getObjectID returns a unique identifier for an object for cycle detection.
+// For indirect refs, uses object number. For direct objects, uses pointer address.
+func getObjectID(o types.Object, xRefTable *XRefTable) uintptr {
+	if ir, ok := o.(types.IndirectRef); ok {
+		// Use object number for indirect refs
+		return uintptr(ir.ObjectNumber)
+	}
+	// For direct objects, use pointer address
+	return uintptr(unsafe.Pointer(&o))
+}
+
 // EqualObjects returns true if two objects are equal in the context of given xrefTable.
 // Some object and an indirect reference to it are treated as equal.
 // Objects may in fact be object trees.
 func EqualObjects(o1, o2 types.Object, xRefTable *XRefTable) (ok bool, err error) {
+	visited := make(map[comparisonKey]bool)
+	return equalObjectsWithVisited(o1, o2, xRefTable, visited)
+}
+
+// equalObjectsWithVisited is the internal implementation with cycle detection.
+func equalObjectsWithVisited(o1, o2 types.Object, xRefTable *XRefTable, visited map[comparisonKey]bool) (ok bool, err error) {
 
 	//log.Debug.Printf("equalObjects: comparing %T with %T \n", o1, o2)
+
+	// Check for cycle before dereferencing
+	id1 := getObjectID(o1, xRefTable)
+	id2 := getObjectID(o2, xRefTable)
+	key := comparisonKey{id1: id1, id2: id2}
+	keyRev := comparisonKey{id1: id2, id2: id1}
+
+	// If we're already comparing this pair, assume equal to break cycle
+	if visited[key] || visited[keyRev] {
+		return true, nil
+	}
 
 	ir1, ok := o1.(types.IndirectRef)
 	if ok {
@@ -41,53 +76,67 @@ func EqualObjects(o1, o2 types.Object, xRefTable *XRefTable) (ok bool, err error
 		}
 	}
 
-	o1, err = xRefTable.Dereference(o1)
+	// Mark as being compared before dereferencing
+	visited[key] = true
+	defer delete(visited, key)
+
+	o1Deref, err := xRefTable.Dereference(o1)
 	if err != nil {
 		return false, err
 	}
 
-	o2, err = xRefTable.Dereference(o2)
+	o2Deref, err := xRefTable.Dereference(o2)
 	if err != nil {
 		return false, err
 	}
 
-	if o1 == nil {
-		return o2 != nil, nil
+	if o1Deref == nil {
+		return o2Deref == nil, nil
 	}
 
-	o1Type := fmt.Sprintf("%T", o1)
-	o2Type := fmt.Sprintf("%T", o2)
-	//log.Debug.Printf("equalObjects: comparing dereferenced %s with %s \n", o1Type, o2Type)
-
-	if o1Type != o2Type {
-		return false, nil
-	}
-
-	switch o1.(type) {
-
+	// Use type switch to check types match and handle comparison in one pass.
+	// This avoids fmt.Sprintf("%T", ...) which can cause stack overflow with circular refs.
+	switch v1 := o1Deref.(type) {
 	case types.Name, types.StringLiteral, types.HexLiteral,
 		types.Integer, types.Float, types.Boolean:
-		ok = o1 == o2
+		// For primitive types, check o2 is same type and compare values
+		switch o2Deref.(type) {
+		case types.Name, types.StringLiteral, types.HexLiteral,
+			types.Integer, types.Float, types.Boolean:
+			ok = v1 == o2Deref
+		default:
+			return false, nil // Different types
+		}
 
 	case types.Dict:
-		ok, err = equalDicts(o1.(types.Dict), o2.(types.Dict), xRefTable)
+		d2, isDict := o2Deref.(types.Dict)
+		if !isDict {
+			return false, nil // Different types
+		}
+		ok, err = equalDicts(v1, d2, xRefTable, visited)
 
 	case types.StreamDict:
-		sd1 := o1.(types.StreamDict)
-		sd2 := o2.(types.StreamDict)
-		ok, err = EqualStreamDicts(&sd1, &sd2, xRefTable)
+		sd2, isStreamDict := o2Deref.(types.StreamDict)
+		if !isStreamDict {
+			return false, nil // Different types
+		}
+		ok, err = equalStreamDictsWithVisited(&v1, &sd2, xRefTable, visited)
 
 	case types.Array:
-		ok, err = equalArrays(o1.(types.Array), o2.(types.Array), xRefTable)
+		a2, isArray := o2Deref.(types.Array)
+		if !isArray {
+			return false, nil // Different types
+		}
+		ok, err = equalArrays(v1, a2, xRefTable, visited)
 
 	default:
-		err = errors.Errorf("equalObjects: unhandled compare for type %s\n", o1Type)
+		err = errors.Errorf("equalObjects: unhandled compare for type %T\n", o1Deref)
 	}
 
 	return ok, err
 }
 
-func equalArrays(a1, a2 types.Array, xRefTable *XRefTable) (bool, error) {
+func equalArrays(a1, a2 types.Array, xRefTable *XRefTable, visited map[comparisonKey]bool) (bool, error) {
 
 	if len(a1) != len(a2) {
 		return false, nil
@@ -95,7 +144,7 @@ func equalArrays(a1, a2 types.Array, xRefTable *XRefTable) (bool, error) {
 
 	for i, o1 := range a1 {
 
-		ok, err := EqualObjects(o1, a2[i], xRefTable)
+		ok, err := equalObjectsWithVisited(o1, a2[i], xRefTable, visited)
 		if err != nil {
 			return false, err
 		}
@@ -110,8 +159,13 @@ func equalArrays(a1, a2 types.Array, xRefTable *XRefTable) (bool, error) {
 
 // EqualStreamDicts returns true if two stream dicts are equal and contain the same bytes.
 func EqualStreamDicts(sd1, sd2 *types.StreamDict, xRefTable *XRefTable) (bool, error) {
+	visited := make(map[comparisonKey]bool)
+	return equalStreamDictsWithVisited(sd1, sd2, xRefTable, visited)
+}
 
-	ok, err := equalDicts(sd1.Dict, sd2.Dict, xRefTable)
+func equalStreamDictsWithVisited(sd1, sd2 *types.StreamDict, xRefTable *XRefTable, visited map[comparisonKey]bool) (bool, error) {
+
+	ok, err := equalDicts(sd1.Dict, sd2.Dict, xRefTable, visited)
 	if err != nil {
 		return false, err
 	}
@@ -163,7 +217,7 @@ func equalFontNames(v1, v2 types.Object, xRefTable *XRefTable) (bool, error) {
 	return bf1 == bf2, nil
 }
 
-func equalDicts(d1, d2 types.Dict, xRefTable *XRefTable) (bool, error) {
+func equalDicts(d1, d2 types.Dict, xRefTable *XRefTable, visited map[comparisonKey]bool) (bool, error) {
 
 	//log.Debug.Printf("equalDicts: %v\n%v\n", d1, d2)
 
@@ -199,7 +253,7 @@ func equalDicts(d1, d2 types.Dict, xRefTable *XRefTable) (bool, error) {
 			continue
 		}
 
-		ok, err := EqualObjects(v1, v2, xRefTable)
+		ok, err := equalObjectsWithVisited(v1, v2, xRefTable, visited)
 		if err != nil {
 			//log.Debug.Printf("equalDict: return4 false, key=%s v1=%v\nv2=%v\n%v\n", key, v1, v2, err)
 			return false, err
@@ -219,6 +273,11 @@ func equalDicts(d1, d2 types.Dict, xRefTable *XRefTable) (bool, error) {
 
 // EqualFontDicts returns true, if two font dicts are equal.
 func EqualFontDicts(fd1, fd2 types.Dict, xRefTable *XRefTable) (bool, error) {
+	visited := make(map[comparisonKey]bool)
+	return equalFontDictsWithVisited(fd1, fd2, xRefTable, visited)
+}
+
+func equalFontDictsWithVisited(fd1, fd2 types.Dict, xRefTable *XRefTable, visited map[comparisonKey]bool) (bool, error) {
 
 	//log.Debug.Printf("EqualFontDicts: %v\n%v\n", fd1, fd2)
 
@@ -230,7 +289,7 @@ func EqualFontDicts(fd1, fd2 types.Dict, xRefTable *XRefTable) (bool, error) {
 		return false, nil
 	}
 
-	ok, err := equalDicts(fd1, fd2, xRefTable)
+	ok, err := equalDicts(fd1, fd2, xRefTable, visited)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/testdata/circular_ref_test.pdf
+++ b/pkg/testdata/circular_ref_test.pdf
@@ -1,0 +1,112 @@
+%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Resources 7 0 R
+/Contents 6 0 R
+>>
+endobj
+
+4 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0 0 100 100]
+/Matrix [1 0 0 1 0 0]
+/Resources 8 0 R
+/Length 2
+>>
+stream
+q
+endstream
+endobj
+
+5 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0 0 100 100]
+/Matrix [1 0 0 1 0 0]
+/Resources 9 0 R
+/Length 2
+>>
+stream
+q
+endstream
+endobj
+
+6 0 obj
+<<
+/Length 8
+>>
+stream
+/F1 Do
+endstream
+endobj
+
+7 0 obj
+<<
+/XObject <<
+/F1 4 0 R
+/F2 5 0 R
+>>
+>>
+endobj
+
+8 0 obj
+<<
+/XObject <<
+/F1 4 0 R
+/F2 5 0 R
+>>
+/ProcSet 9 0 R
+>>
+endobj
+
+9 0 obj
+<<
+/XObject <<
+/F1 4 0 R
+/F2 5 0 R
+>>
+/ProcSet 8 0 R
+>>
+endobj
+
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000059 00000 n 
+0000000117 00000 n 
+0000000222 00000 n 
+0000000362 00000 n 
+0000000502 00000 n 
+0000000558 00000 n 
+0000000615 00000 n 
+0000000687 00000 n 
+trailer
+<<
+/Size 10
+/Root 1 0 R
+>>
+startxref
+1005
+%%EOF


### PR DESCRIPTION
Add cycle detection to prevent infinite recursion when comparing PDF
objects with circular references in their Resources dictionaries.

The bug occurs when optimize compares Form XObjects with identical
stream lengths that have circular references in their Resources
dictionaries (e.g., Resources dict A references Resources dict B via
ProcSet, and B references A back). This causes infinite recursion in
EqualObjects -> equalDicts -> EqualObjects.

Changes:
- Add visited map and comparisonKey struct to track object comparisons
- Implement cycle detection in equalObjectsWithVisited, equalDicts,
  equalStreamDictsWithVisited, and equalArrays
- Replace fmt.Sprintf type introspection with explicit type assertions
  to avoid stack overflow in deeply nested structures
- Add comprehensive tests for optimize and watermark operations with
  circular references (API and CLI)

Test: Added circular_ref_test.pdf to testdata for regression testing.