### PR TITLE
test: isolate test output from pkg/samples/ to temp directories

### DIFF
--- a/pkg/api/test/annotation_test.go
+++ b/pkg/api/test/annotation_test.go
@@ -571,10 +571,15 @@ func TestAddAnnotationsLowLevel(t *testing.T) {
 func TestAddLinkAnnotationWithDest(t *testing.T) {
 	msg := "TestAddLinkAnnotationWithDest"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "Walden.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "LinkAnnotWithDestTopLeft.pdf")
+	outFile := filepath.Join(annDir, "LinkAnnotWithDestTopLeft.pdf")
 
 	// Create internal link:
 	// Add a 100x100 link rectangle on the bottom left corner of page 2.
@@ -606,10 +611,15 @@ func TestAddLinkAnnotationWithDest(t *testing.T) {
 func TestAddAnnotationsFile(t *testing.T) {
 	msg := "TestAddAnnotationsFile"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "Annotations.pdf")
+	outFile := filepath.Join(annDir, "Annotations.pdf")
 
 	// Add text annotation.
 	if err := api.AddAnnotationsFile(inFile, outFile, nil, textAnn, nil, false); err != nil {
@@ -689,11 +699,16 @@ func TestAddAnnotations(t *testing.T) {
 func TestPopupAnnotation(t *testing.T) {
 	msg := "TestPopupAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Add a Markup annotation and a linked Popup annotation.
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "PopupAnnotation.pdf")
+	outFile := filepath.Join(annDir, "PopupAnnotation.pdf")
 
 	incr := false
 	pageNr := 1
@@ -744,10 +759,15 @@ func TestPopupAnnotation(t *testing.T) {
 func TestInkAnnotation(t *testing.T) {
 	msg := "TestInkAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "InkAnnotation.pdf")
+	outFile := filepath.Join(annDir, "InkAnnotation.pdf")
 
 	p1 := model.InkPath{100., 542., 150., 492., 200., 542.}
 	p2 := model.InkPath{100, 592, 150, 592}
@@ -779,10 +799,15 @@ func TestInkAnnotation(t *testing.T) {
 func TestHighlightAnnotation(t *testing.T) {
 	msg := "TestHighlightAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "testWithText.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "HighlightAnnotation.pdf")
+	outFile := filepath.Join(annDir, "HighlightAnnotation.pdf")
 
 	r := types.NewRectangle(205, 624.16, 400, 645.88)
 
@@ -816,10 +841,15 @@ func TestHighlightAnnotation(t *testing.T) {
 func TestUnderlineAnnotation(t *testing.T) {
 	msg := "TestUnderlineAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "testWithText.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "UnderlineAnnotation.pdf")
+	outFile := filepath.Join(annDir, "UnderlineAnnotation.pdf")
 
 	r := types.NewRectangle(205, 624.16, 400, 645.88)
 
@@ -853,10 +883,15 @@ func TestUnderlineAnnotation(t *testing.T) {
 func TestSquigglyAnnotation(t *testing.T) {
 	msg := "TestSquigglyAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "testWithText.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "SquigglyAnnotation.pdf")
+	outFile := filepath.Join(annDir, "SquigglyAnnotation.pdf")
 
 	r := types.NewRectangle(205, 624.16, 400, 645.88)
 
@@ -890,10 +925,15 @@ func TestSquigglyAnnotation(t *testing.T) {
 func TestStrikeOutAnnotation(t *testing.T) {
 	msg := "TestStrikeOutAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "testWithText.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "StrikeOutAnnotation.pdf")
+	outFile := filepath.Join(annDir, "StrikeOutAnnotation.pdf")
 
 	r := types.NewRectangle(205, 624.16, 400, 645.88)
 
@@ -927,10 +967,15 @@ func TestStrikeOutAnnotation(t *testing.T) {
 func TestFreeTextAnnotation(t *testing.T) {
 	msg := "TestFreeTextAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "FreeTextAnnotation.pdf")
+	outFile := filepath.Join(annDir, "FreeTextAnnotation.pdf")
 
 	// Add Free text annotation.
 	if err := api.AddAnnotationsFile(inFile, outFile, nil, freeTextAnn, nil, false); err != nil {
@@ -941,10 +986,15 @@ func TestFreeTextAnnotation(t *testing.T) {
 func TestPolyLineAnnotation(t *testing.T) {
 	msg := "TestPolyLineAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "PolyLineAnnotation.pdf")
+	outFile := filepath.Join(annDir, "PolyLineAnnotation.pdf")
 
 	leButt := model.LEButt
 	leOpenArrow := model.LEOpenArrow
@@ -982,10 +1032,15 @@ func TestPolyLineAnnotation(t *testing.T) {
 func TestPolygonAnnotation(t *testing.T) {
 	msg := "TestPolygonAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "PolygonAnnotation.pdf")
+	outFile := filepath.Join(annDir, "PolygonAnnotation.pdf")
 
 	polygonAnn := model.NewPolygonAnnotation(
 		*types.NewRectangle(30, 30, 110, 110), // rect
@@ -1019,10 +1074,15 @@ func TestPolygonAnnotation(t *testing.T) {
 func TestLineAnnotation(t *testing.T) {
 	msg := "TestLineAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "LineAnnotation.pdf")
+	outFile := filepath.Join(annDir, "LineAnnotation.pdf")
 
 	leOpenArrow := model.LEOpenArrow
 
@@ -1065,10 +1125,15 @@ func TestLineAnnotation(t *testing.T) {
 func TestCaretAnnotation(t *testing.T) {
 	msg := "TestCaretAnnotation"
 
+	annDir := filepath.Join(outDir, "annotations")
+	if err := os.MkdirAll(annDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	// Best viewed with Adobe Reader.
 
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "annotations", "CaretAnnotation.pdf")
+	outFile := filepath.Join(annDir, "CaretAnnotation.pdf")
 
 	caretAnn := model.NewCaretAnnotation(
 		*types.NewRectangle(30, 30, 110, 110), // rect

--- a/pkg/api/test/booklet_test.go
+++ b/pkg/api/test/booklet_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,7 +52,10 @@ func testBooklet(t *testing.T, msg string, inFiles []string, outFile string, sel
 }
 
 func TestBooklet(t *testing.T) {
-	outDir := filepath.Join("..", "..", "samples", "booklet")
+	outDir := filepath.Join(outDir, "booklet")
+	if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
+		t.Fatalf("TestBooklet mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg           string

--- a/pkg/api/test/bookmark_test.go
+++ b/pkg/api/test/bookmark_test.go
@@ -58,8 +58,8 @@ func listBookmarksFile(t *testing.T, fileName string, conf *model.Configuration)
 
 func TestListBookmarks(t *testing.T) {
 	msg := "TestListBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
-	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
+	bmInDir := filepath.Join(samplesDir, "bookmarks")
+	inFile := filepath.Join(bmInDir, "bookmarkTree.pdf")
 
 	if _, err := listBookmarksFile(t, inFile, nil); err != nil {
 		t.Fatalf("%s list bookmarks: %v\n", msg, err)
@@ -69,7 +69,11 @@ func TestListBookmarks(t *testing.T) {
 func TestAddDuplicateBookmarks(t *testing.T) {
 	msg := "TestAddDuplicateBookmarks"
 	inFile := filepath.Join(inDir, "CenterOfWhy.pdf")
-	outFile := filepath.Join("..", "..", "samples", "bookmarks", "bookmarkDuplicates.pdf")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkDuplicates.pdf")
 
 	bms := []pdfcpu.Bookmark{
 		{PageFrom: 1, Title: "Parent1",
@@ -98,7 +102,11 @@ func TestAddDuplicateBookmarks(t *testing.T) {
 func TestAddSimpleBookmarks(t *testing.T) {
 	msg := "TestAddSimpleBookmarks"
 	inFile := filepath.Join(inDir, "CenterOfWhy.pdf")
-	outFile := filepath.Join("..", "..", "samples", "bookmarks", "bookmarkSimple.pdf")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkSimple.pdf")
 
 	bookmarkColor := color.NewSimpleColor(0xab6f30)
 
@@ -127,7 +135,11 @@ func TestAddSimpleBookmarks(t *testing.T) {
 func TestAddBookmarkTree2Levels(t *testing.T) {
 	msg := "TestAddBookmarkTree2Levels"
 	inFile := filepath.Join(inDir, "CenterOfWhy.pdf")
-	outFile := filepath.Join("..", "..", "samples", "bookmarks", "bookmarkTree.pdf")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkTree.pdf")
 
 	bms := []pdfcpu.Bookmark{
 		{PageFrom: 1, Title: "Page 1: Level 1", Color: &color.Green,
@@ -156,9 +168,13 @@ func TestAddBookmarkTree2Levels(t *testing.T) {
 
 func TestRemoveBookmarks(t *testing.T) {
 	msg := "TestRemoveBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
-	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
-	outFile := filepath.Join(inDir, "bookmarkTreeNoBookmarks.pdf")
+	bmInDir := filepath.Join(samplesDir, "bookmarks")
+	inFile := filepath.Join(bmInDir, "bookmarkTree.pdf")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkTreeNoBookmarks.pdf")
 
 	if err := api.RemoveBookmarksFile(inFile, outFile, nil); err != nil {
 		t.Fatalf("%s removeBookmarks: %v\n", msg, err)
@@ -170,9 +186,13 @@ func TestRemoveBookmarks(t *testing.T) {
 
 func TestExportBookmarks(t *testing.T) {
 	msg := "TestExportBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
-	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
-	outFile := filepath.Join(inDir, "bookmarkTree.json")
+	bmInDir := filepath.Join(samplesDir, "bookmarks")
+	inFile := filepath.Join(bmInDir, "bookmarkTree.pdf")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkTree.json")
 
 	if err := api.ExportBookmarksFile(inFile, outFile, nil); err != nil {
 		t.Fatalf("%s export bookmarks: %v\n", msg, err)
@@ -181,10 +201,14 @@ func TestExportBookmarks(t *testing.T) {
 
 func TestImportBookmarks(t *testing.T) {
 	msg := "TestImportBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
-	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
-	inFileJSON := filepath.Join(inDir, "bookmarkTree.json")
-	outFile := filepath.Join(inDir, "bookmarkTreeImported.pdf")
+	bmInDir := filepath.Join(samplesDir, "bookmarks")
+	inFile := filepath.Join(bmInDir, "bookmarkTree.pdf")
+	inFileJSON := filepath.Join(bmInDir, "bookmarkTree.json")
+	bmOutDir := filepath.Join(outDir, "bookmarks")
+	if err := os.MkdirAll(bmOutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(bmOutDir, "bookmarkTreeImported.pdf")
 
 	replace := true
 	if err := api.ImportBookmarksFile(inFile, inFileJSON, outFile, replace, nil); err != nil {

--- a/pkg/api/test/createFromJSON_test.go
+++ b/pkg/api/test/createFromJSON_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,8 +56,11 @@ func createPDF(t *testing.T, msg, inFile, inFileJSON, outFile string, conf *mode
 func TestCreateContentPrimitivesViaJson(t *testing.T) {
 
 	t.Helper()
-	inDir := filepath.Join(inDir, "json", "create")
-	outDir := filepath.Join(samplesDir, "create", "primitives")
+	jsonInDir := filepath.Join(inDir, "json", "create")
+	createPrimDir := filepath.Join(outDir, "create", "primitives")
+	if err := os.MkdirAll(createPrimDir, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateContentPrimitivesViaJson mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg        string
@@ -93,8 +97,8 @@ func TestCreateContentPrimitivesViaJson(t *testing.T) {
 		{"TestRegions", "regions.json", "regions.pdf"},
 		{"TestRegionsMarginBorderPadding", "regionsMargBordPadd.json", "regionsMarginBorderPadding.pdf"},
 	} {
-		inFileJSON := filepath.Join(inDir, tt.inFileJSON)
-		outFile := filepath.Join(outDir, tt.outFile)
+		inFileJSON := filepath.Join(jsonInDir, tt.inFileJSON)
+		outFile := filepath.Join(createPrimDir, tt.outFile)
 		createPDF(t, tt.msg, "", inFileJSON, outFile, conf)
 	}
 
@@ -103,7 +107,10 @@ func TestCreateContentPrimitivesViaJson(t *testing.T) {
 func TestCreateFormPrimitivesViaJson(t *testing.T) {
 
 	inDirForm := filepath.Join(inDir, "json", "form")
-	outDirForm := filepath.Join(samplesDir, "form", "primitives")
+	outDirForm := filepath.Join(outDir, "form", "primitives")
+	if err := os.MkdirAll(outDirForm, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateFormPrimitivesViaJson mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg        string
@@ -157,7 +164,10 @@ func TestCreateSinglePageDemoFormsViaJson(t *testing.T) {
 	// Render single page demo forms for export, reset, lock, unlock and fill tests.
 
 	inDirFormDemo := filepath.Join(inDir, "json", "form", "demoSinglePage")
-	outDirFormDemo := filepath.Join(samplesDir, "form", "demoSinglePage")
+	outDirFormDemo := filepath.Join(outDir, "form", "demoSinglePage")
+	if err := os.MkdirAll(outDirFormDemo, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateSinglePageDemoFormsViaJson mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg        string
@@ -180,7 +190,10 @@ func TestCreateSinglePageDemoFormsViaJson(t *testing.T) {
 func TestCreateDemoFormsViaJson(t *testing.T) {
 
 	inDirFormDemo := filepath.Join(inDir, "json", "form", "demo")
-	outDirFormDemo := filepath.Join(samplesDir, "form", "demo")
+	outDirFormDemo := filepath.Join(outDir, "form", "demo")
+	if err := os.MkdirAll(outDirFormDemo, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateDemoFormsViaJson mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg        string
@@ -256,18 +269,21 @@ func TestCreateAndUpdatePageViaJson(t *testing.T) {
 	// 	 b) on different page
 
 	jsonDir := filepath.Join(inDir, "json", "create", "flow")
-	outDir := filepath.Join(samplesDir, "create", "flow")
+	flowDir := filepath.Join(outDir, "create", "flow")
+	if err := os.MkdirAll(flowDir, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateAndUpdatePageViaJson mkdirAll: %v\n", err)
+	}
 
-	// Create PDF in outDir.
+	// Create PDF in flowDir.
 	inFileJSON1 := filepath.Join(jsonDir, "createPage.json")
-	file := filepath.Join(outDir, "createAndUpdatePage.pdf")
+	file := filepath.Join(flowDir, "createAndUpdatePage.pdf")
 	createPDF(t, "pass1", "", inFileJSON1, file, conf)
 
-	// Update PDF in outDir: reuse fonts from (same) page 1
+	// Update PDF in flowDir: reuse fonts from (same) page 1
 	inFileJSON2 := filepath.Join(jsonDir, "updatePage1.json")
 	createPDF(t, "pass2", file, inFileJSON2, file, conf)
 
-	// Update PDF in outDir: reuse fonts from (different) page 1
+	// Update PDF in flowDir: reuse fonts from (different) page 1
 	inFileJSON3 := filepath.Join(jsonDir, "updatePage2.json")
 	createPDF(t, "pass2", file, inFileJSON3, file, conf)
 }
@@ -281,15 +297,18 @@ func TestReadAndUpdatePageViaJson(t *testing.T) {
 	// 	 b) on different page
 
 	jsonDir := filepath.Join(inDir, "json", "create", "flow")
-	outDir := filepath.Join(samplesDir, "create", "flow")
+	flowDir := filepath.Join(outDir, "create", "flow")
+	if err := os.MkdirAll(flowDir, os.ModePerm); err != nil {
+		t.Fatalf("TestReadAndUpdatePageViaJson mkdirAll: %v\n", err)
+	}
 
-	// Update PDF in outDir.
+	// Update PDF in flowDir.
 	inFile := filepath.Join(inDir, "Walden.pdf")
 	inFileJSON1 := filepath.Join(jsonDir, "updateAnyPage1.json")
-	outFile := filepath.Join(outDir, "readAndUpdatePage.pdf")
+	outFile := filepath.Join(flowDir, "readAndUpdatePage.pdf")
 	createPDF(t, "pass", inFile, inFileJSON1, outFile, conf)
 
-	// Update PDF in outDir: reuse fonts from (different) page 1 and create new page
+	// Update PDF in flowDir: reuse fonts from (different) page 1 and create new page
 	inFileJSON2 := filepath.Join(jsonDir, "updateAnyPage2.json")
 	createPDF(t, "pass2", outFile, inFileJSON2, outFile, conf)
 }
@@ -301,29 +320,32 @@ func TestCreateFormAndUpdatePageViaJson(t *testing.T) {
 	// 2. Add content
 
 	jsonDir := filepath.Join(inDir, "json", "form")
-	outDir := filepath.Join(samplesDir, "form", "flow")
+	formFlowDir := filepath.Join(outDir, "form", "flow")
+	if err := os.MkdirAll(formFlowDir, os.ModePerm); err != nil {
+		t.Fatalf("TestCreateFormAndUpdatePageViaJson mkdirAll: %v\n", err)
+	}
 
-	// Create PDF form in outDir and add content using corefont.
+	// Create PDF form in formFlowDir and add content using corefont.
 	inFileJSON1 := filepath.Join(jsonDir, "demo", "english.json")
-	file := filepath.Join(outDir, "createFormAndUpdatePageCoreFont.pdf")
+	file := filepath.Join(formFlowDir, "createFormAndUpdatePageCoreFont.pdf")
 	createPDF(t, "pass1", "", inFileJSON1, file, conf)
-	// Update PDF form in outDir reusing page font.
+	// Update PDF form in formFlowDir reusing page font.
 	inFileJSON2 := filepath.Join(jsonDir, "flow", "updatePageCoreFont.json")
 	createPDF(t, "pass2", file, inFileJSON2, file, conf)
 
-	// Create PDF form in outDir and add content using userfont.
+	// Create PDF form in formFlowDir and add content using userfont.
 	inFileJSON1 = filepath.Join(jsonDir, "demo", "ukrainian.json")
-	file = filepath.Join(outDir, "createFormAndUpdatePageUserFont.pdf")
+	file = filepath.Join(formFlowDir, "createFormAndUpdatePageUserFont.pdf")
 	createPDF(t, "pass1", "", inFileJSON1, file, conf)
-	// Update PDF form in outDir reusing page font.
+	// Update PDF form in formFlowDir reusing page font.
 	inFileJSON2 = filepath.Join(jsonDir, "flow", "updatePageUserFont.json")
 	createPDF(t, "pass2", file, inFileJSON2, file, conf)
 
-	// Create PDF form in outDir and add content using CJK userfont.
+	// Create PDF form in formFlowDir and add content using CJK userfont.
 	inFileJSON1 = filepath.Join(jsonDir, "demo", "chineseSimple.json")
-	file = filepath.Join(outDir, "createFormAndUpdatePageCJKUserFont.pdf")
+	file = filepath.Join(formFlowDir, "createFormAndUpdatePageCJKUserFont.pdf")
 	createPDF(t, "pass1", "", inFileJSON1, file, conf)
-	// Update PDF form in outDir reusing page font.
+	// Update PDF form in formFlowDir reusing page font.
 	inFileJSON2 = filepath.Join(jsonDir, "flow", "updatePageCJKUserFont.json")
 	createPDF(t, "pass2", file, inFileJSON2, file, conf)
 }
@@ -335,23 +357,26 @@ func TestReadFormAndUpdateFormViaJson(t *testing.T) {
 	// 2. Add fields
 
 	jsonDir := filepath.Join(inDir, "json", "form", "flow")
-	outDir := filepath.Join(samplesDir, "form", "flow")
+	formFlowDir := filepath.Join(outDir, "form", "flow")
+	if err := os.MkdirAll(formFlowDir, os.ModePerm); err != nil {
+		t.Fatalf("TestReadFormAndUpdateFormViaJson mkdirAll: %v\n", err)
+	}
 
-	// Read demo form and update with corefont in outDir.
+	// Read demo form and update with corefont in formFlowDir.
 	inFile := filepath.Join(samplesDir, "form", "demo", "english.pdf")
 	inFileJSON := filepath.Join(jsonDir, "updateFormCoreFont.json")
-	outFile := filepath.Join(outDir, "readFormAndUpdateFormCoreFont.pdf")
+	outFile := filepath.Join(formFlowDir, "readFormAndUpdateFormCoreFont.pdf")
 	createPDF(t, "pass1", inFile, inFileJSON, outFile, conf)
 
-	// Read demo form and update with userfont in outDir.
+	// Read demo form and update with userfont in formFlowDir.
 	inFile = filepath.Join(samplesDir, "form", "demo", "ukrainian.pdf")
 	inFileJSON = filepath.Join(jsonDir, "updateFormUserFont.json")
-	outFile = filepath.Join(outDir, "readFormAndUpdateFormUserFont.pdf")
+	outFile = filepath.Join(formFlowDir, "readFormAndUpdateFormUserFont.pdf")
 	createPDF(t, "pass1", inFile, inFileJSON, outFile, conf)
 
-	// Read demo form and update with CJK userfont in outDir.
+	// Read demo form and update with CJK userfont in formFlowDir.
 	inFile = filepath.Join(samplesDir, "form", "demo", "chineseSimple.pdf")
 	inFileJSON = filepath.Join(jsonDir, "updateFormCJK.json")
-	outFile = filepath.Join(outDir, "readFormAndUpdateFormCJK.pdf")
+	outFile = filepath.Join(formFlowDir, "readFormAndUpdateFormCJK.pdf")
 	createPDF(t, "pass1", inFile, inFileJSON, outFile, conf)
 }

--- a/pkg/api/test/createUserFont_test.go
+++ b/pkg/api/test/createUserFont_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
@@ -574,7 +573,5 @@ func TestUserFonts(t *testing.T) {
 	if err = pdfcpu.AddPageTreeWithSamplePage(xRefTable, rootDict, p); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	outDir := filepath.Join("..", "..", "samples", "basic")
-	outFile := filepath.Join(outDir, "UserFont_HumanRights.pdf")
-	createAndValidate(t, xRefTable, outFile, msg)
+	createAndValidate(t, xRefTable, "UserFont_HumanRights.pdf", msg)
 }

--- a/pkg/api/test/create_test.go
+++ b/pkg/api/test/create_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -162,8 +163,11 @@ parents during vacation--so there was no bright side to life anywhere.`
 
 func createAndValidate(t *testing.T, xRefTable *model.XRefTable, outFile, msg string) {
 	t.Helper()
-	outDir := "../../samples/basic"
-	outFile = filepath.Join(outDir, outFile)
+	basicDir := filepath.Join(outDir, "basic")
+	if err := os.MkdirAll(basicDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile = filepath.Join(basicDir, outFile)
 	if err := api.CreatePDFFile(xRefTable, outFile, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
@@ -1678,9 +1682,7 @@ func createXRefAndWritePDF(t *testing.T, msg, fileName string, mediaBox *types.R
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 
-	outDir := filepath.Join("..", "..", "samples", "basic")
-	outFile := filepath.Join(outDir, fileName+".pdf")
-	createAndValidate(t, xRefTable, outFile, msg)
+	createAndValidate(t, xRefTable, fileName+".pdf", msg)
 }
 
 func testTextDemoPDF(t *testing.T, msg, fileName string, w, h int, hAlign types.HAlignment) {
@@ -1907,9 +1909,7 @@ func createXRefAndWriteJustifiedPDF(t *testing.T, msg, fileName string, mediaBox
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 
-	outDir := filepath.Join("..", "..", "samples", "basic")
-	outFile := filepath.Join(outDir, fileName+".pdf")
-	createAndValidate(t, xRefTable, outFile, msg)
+	createAndValidate(t, xRefTable, fileName+".pdf", msg)
 }
 
 func TestUserFontJustified(t *testing.T) {
@@ -1940,9 +1940,7 @@ func createXRefAndWriteRTLPDF(t *testing.T,
 	if err = pdfcpu.AddPageTreeWithSamplePage(xRefTable, rootDict, p); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	outDir := filepath.Join("..", "..", "samples", "basic")
-	outFile := filepath.Join(outDir, fileName+".pdf")
-	createAndValidate(t, xRefTable, outFile, msg)
+	createAndValidate(t, xRefTable, fileName+".pdf", msg)
 }
 
 func TestUserFontRTL(t *testing.T) {
@@ -2063,7 +2061,5 @@ func TestCJKV(t *testing.T) {
 	if err = pdfcpu.AddPageTreeWithSamplePage(xRefTable, rootDict, p); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
-	outDir := filepath.Join("..", "..", "samples", "basic")
-	outFile := filepath.Join(outDir, "UserFont_CJKV.pdf")
-	createAndValidate(t, xRefTable, outFile, msg)
+	createAndValidate(t, xRefTable, "UserFont_CJKV.pdf", msg)
 }

--- a/pkg/api/test/cut_test.go
+++ b/pkg/api/test/cut_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,7 +26,7 @@ import (
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 )
 
-func testCut(t *testing.T, msg, inFile, outDir, outFile string, unit types.DisplayUnit, cutConf string) {
+func testCut(t *testing.T, msg, inFile, outSubDir, outFile string, unit types.DisplayUnit, cutConf string) {
 	t.Helper()
 
 	cut, err := pdfcpu.ParseCutConfig(cutConf, unit)
@@ -34,9 +35,12 @@ func testCut(t *testing.T, msg, inFile, outDir, outFile string, unit types.Displ
 	}
 
 	inFile = filepath.Join(inDir, inFile)
-	outDir = filepath.Join(samplesDir, outDir)
+	cutDir := filepath.Join(outDir, outSubDir)
+	if err := os.MkdirAll(cutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
-	if err := api.CutFile(inFile, outDir, outFile, nil, cut, nil); err != nil {
+	if err := api.CutFile(inFile, cutDir, outFile, nil, cut, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 }
@@ -95,7 +99,7 @@ func TestCut(t *testing.T) {
 	}
 }
 
-func testNDown(t *testing.T, msg, inFile, outDir, outFile string, n int, unit types.DisplayUnit, cutConf string) {
+func testNDown(t *testing.T, msg, inFile, outSubDir, outFile string, n int, unit types.DisplayUnit, cutConf string) {
 	t.Helper()
 
 	cut, err := pdfcpu.ParseCutConfigForN(n, cutConf, unit)
@@ -104,9 +108,12 @@ func testNDown(t *testing.T, msg, inFile, outDir, outFile string, n int, unit ty
 	}
 
 	inFile = filepath.Join(inDir, inFile)
-	outDir = filepath.Join(samplesDir, outDir)
+	cutDir := filepath.Join(outDir, outSubDir)
+	if err := os.MkdirAll(cutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
-	if err := api.NDownFile(inFile, outDir, outFile, nil, n, cut, nil); err != nil {
+	if err := api.NDownFile(inFile, cutDir, outFile, nil, n, cut, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 }
@@ -156,7 +163,7 @@ func TestNDown(t *testing.T) {
 	}
 }
 
-func testPoster(t *testing.T, msg, inFile, outDir, outFile string, unit types.DisplayUnit, cutConf string) {
+func testPoster(t *testing.T, msg, inFile, outSubDir, outFile string, unit types.DisplayUnit, cutConf string) {
 	t.Helper()
 
 	cut, err := pdfcpu.ParseCutConfigForPoster(cutConf, unit)
@@ -165,9 +172,12 @@ func testPoster(t *testing.T, msg, inFile, outDir, outFile string, unit types.Di
 	}
 
 	inFile = filepath.Join(inDir, inFile)
-	outDir = filepath.Join(samplesDir, outDir)
+	cutDir := filepath.Join(outDir, outSubDir)
+	if err := os.MkdirAll(cutDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
-	if err := api.PosterFile(inFile, outDir, outFile, nil, cut, nil); err != nil {
+	if err := api.PosterFile(inFile, cutDir, outFile, nil, cut, nil); err != nil {
 		t.Fatalf("%s: %v\n", msg, err)
 	}
 }

--- a/pkg/api/test/font_test.go
+++ b/pkg/api/test/font_test.go
@@ -18,7 +18,7 @@ package test
 
 import (
 	"fmt"
-
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -111,8 +111,17 @@ func TestCoreFontDemoPDF(t *testing.T) {
 		if err = pdfcpu.AddPageTreeWithSamplePage(xRefTable, rootDict, p); err != nil {
 			t.Fatalf("%s: %v\n", msg, err)
 		}
-		outFile := filepath.Join("..", "..", "samples", "fonts", "core", fn+".pdf")
-		createAndValidate(t, xRefTable, outFile, msg)
+		coreDir := filepath.Join(outDir, "fonts", "core")
+		if err = os.MkdirAll(coreDir, os.ModePerm); err != nil {
+			t.Fatalf("%s mkdirAll: %v\n", msg, err)
+		}
+		outFile := filepath.Join(coreDir, fn+".pdf")
+		if err = api.CreatePDFFile(xRefTable, outFile, nil); err != nil {
+			t.Fatalf("%s: %v\n", msg, err)
+		}
+		if err = api.ValidateFile(outFile, nil); err != nil {
+			t.Fatalf("%s: %v\n", msg, err)
+		}
 	}
 }
 
@@ -123,7 +132,11 @@ func TestUserFontDemoPDF(t *testing.T) {
 	// in pkg/samples/fonts/user.
 	for _, fn := range font.UserFontNames() {
 		fmt.Println(fn)
-		if err := api.CreateUserFontDemoFiles(filepath.Join("..", "..", "samples", "fonts", "user"), fn); err != nil {
+		userDir := filepath.Join(outDir, "fonts", "user")
+		if err := os.MkdirAll(userDir, os.ModePerm); err != nil {
+			t.Fatalf("%s mkdirAll: %v\n", msg, err)
+		}
+		if err := api.CreateUserFontDemoFiles(userDir, fn); err != nil {
 			t.Fatalf("%s: %v\n", msg, err)
 		}
 	}

--- a/pkg/api/test/form_test.go
+++ b/pkg/api/test/form_test.go
@@ -26,6 +26,17 @@ import (
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 )
 
+// formOutDir creates and returns a subdirectory under the package-level outDir.
+func formOutDir(t *testing.T, subPaths ...string) string {
+	t.Helper()
+	parts := append([]string{outDir, "form"}, subPaths...)
+	d := filepath.Join(parts...)
+	if err := os.MkdirAll(d, os.ModePerm); err != nil {
+		t.Fatalf("formOutDir mkdirAll %s: %v\n", d, err)
+	}
+	return d
+}
+
 /**************************************************************
  * All form related processing is optimized for Adobe Reader! *
  **************************************************************/
@@ -73,7 +84,7 @@ func TestRemoveFormFields(t *testing.T) {
 
 	msg := "TestRemoveFormFields"
 	inFile := filepath.Join(samplesDir, "form", "demo", "english.pdf")
-	outFile := filepath.Join(samplesDir, "form", "remove", "removedField.pdf")
+	outFile := filepath.Join(formOutDir(t, "remove"), "removedField.pdf")
 
 	ss, err := listFormFieldsFile(t, inFile, conf)
 	if err != nil {
@@ -110,7 +121,7 @@ func TestResetFormFields(t *testing.T) {
 		{"TestResetPersonForm", "person.pdf", "person-reset.pdf"},            // Person Form
 	} {
 		inFile := filepath.Join(samplesDir, "form", "demoSinglePage", tt.inFile)
-		outFile := filepath.Join(samplesDir, "form", "reset", tt.outFile)
+		outFile := filepath.Join(formOutDir(t, "reset"), tt.outFile)
 		if err := api.ResetFormFieldsFile(inFile, outFile, nil, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
@@ -132,7 +143,7 @@ func TestLockFormFields(t *testing.T) {
 		{"TestLockPersonForm", "person.pdf", "person-locked.pdf"},            // Person Form
 	} {
 		inFile := filepath.Join(samplesDir, "form", "demoSinglePage", tt.inFile)
-		outFile := filepath.Join(samplesDir, "form", "lock", tt.outFile)
+		outFile := filepath.Join(formOutDir(t, "lock"), tt.outFile)
 		if err := api.LockFormFieldsFile(inFile, outFile, nil, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
@@ -153,7 +164,7 @@ func TestUnlockFormFields(t *testing.T) {
 		{"TestUnlockPersonForm", "person-locked.pdf", "person-unlocked.pdf"},            // Person Form
 	} {
 		inFile := filepath.Join(samplesDir, "form", "lock", tt.inFile)
-		outFile := filepath.Join(samplesDir, "form", "lock", tt.outFile)
+		outFile := filepath.Join(formOutDir(t, "lock"), tt.outFile)
 		if err := api.UnlockFormFieldsFile(inFile, outFile, nil, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
@@ -163,7 +174,7 @@ func TestUnlockFormFields(t *testing.T) {
 func TestExportForm(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
-	outDir := filepath.Join(samplesDir, "form", "export")
+	exportDir := formOutDir(t, "export")
 
 	for _, tt := range []struct {
 		msg     string
@@ -177,7 +188,7 @@ func TestExportForm(t *testing.T) {
 		{"TestExportPersonForm", "person.pdf", "person.json"},            // Person Form
 	} {
 		inFile := filepath.Join(inDir, tt.inFile)
-		outFile := filepath.Join(outDir, tt.outFile)
+		outFile := filepath.Join(exportDir, tt.outFile)
 		if err := api.ExportFormFile(inFile, outFile, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
@@ -188,7 +199,7 @@ func TestFillForm(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
 	jsonDir := filepath.Join(samplesDir, "form", "fill")
-	outDir := jsonDir
+	fillOutDir := formOutDir(t, "fill")
 
 	for _, tt := range []struct {
 		msg        string
@@ -204,7 +215,7 @@ func TestFillForm(t *testing.T) {
 	} {
 		inFile := filepath.Join(inDir, tt.inFile)
 		inFileJSON := filepath.Join(jsonDir, tt.inFileJSON)
-		outFile := filepath.Join(outDir, tt.outFile)
+		outFile := filepath.Join(fillOutDir, tt.outFile)
 		if err := api.FillFormFile(inFile, inFileJSON, outFile, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
@@ -215,7 +226,7 @@ func TestMultiFillFormJSON(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
 	jsonDir := filepath.Join(samplesDir, "form", "multifill", "json")
-	outDir := jsonDir
+	mfOutDir := formOutDir(t, "multifill", "json")
 
 	for _, tt := range []struct {
 		msg        string
@@ -227,7 +238,7 @@ func TestMultiFillFormJSON(t *testing.T) {
 	} {
 		inFile := filepath.Join(inDir, tt.inFile)
 		inFileJSON := filepath.Join(jsonDir, tt.inFileJSON)
-		if err := api.MultiFillFormFile(inFile, inFileJSON, outDir, inFile, false, conf); err != nil {
+		if err := api.MultiFillFormFile(inFile, inFileJSON, mfOutDir, inFile, false, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 	}
@@ -237,7 +248,7 @@ func TestMultiFillFormJSONMerged(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
 	jsonDir := filepath.Join(samplesDir, "form", "multifill", "json")
-	outDir := filepath.Join(jsonDir, "merge")
+	mfMergeDir := formOutDir(t, "multifill", "json", "merge")
 
 	for _, tt := range []struct {
 		msg        string
@@ -249,7 +260,7 @@ func TestMultiFillFormJSONMerged(t *testing.T) {
 	} {
 		inFile := filepath.Join(inDir, tt.inFile)
 		inFileJSON := filepath.Join(jsonDir, tt.inFileJSON)
-		if err := api.MultiFillFormFile(inFile, inFileJSON, outDir, inFile, true, conf); err != nil {
+		if err := api.MultiFillFormFile(inFile, inFileJSON, mfMergeDir, inFile, true, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 	}
@@ -259,7 +270,7 @@ func TestMultiFillFormCSV(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
 	csvDir := filepath.Join(samplesDir, "form", "multifill", "csv")
-	outDir := csvDir
+	csvOutDir := formOutDir(t, "multifill", "csv")
 
 	for _, tt := range []struct {
 		msg       string
@@ -272,7 +283,7 @@ func TestMultiFillFormCSV(t *testing.T) {
 
 		inFile := filepath.Join(inDir, tt.inFile)
 		inFileCSV := filepath.Join(csvDir, tt.inFileCSV)
-		if err := api.MultiFillFormFile(inFile, inFileCSV, outDir, inFile, false, conf); err != nil {
+		if err := api.MultiFillFormFile(inFile, inFileCSV, csvOutDir, inFile, false, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 	}
@@ -282,7 +293,7 @@ func TestMultiFillFormCSVMerged(t *testing.T) {
 
 	inDir := filepath.Join(samplesDir, "form", "demoSinglePage")
 	csvDir := filepath.Join(samplesDir, "form", "multifill", "csv")
-	outDir := filepath.Join(csvDir, "merge")
+	csvMergeDir := formOutDir(t, "multifill", "csv", "merge")
 
 	for _, tt := range []struct {
 		msg       string
@@ -295,7 +306,7 @@ func TestMultiFillFormCSVMerged(t *testing.T) {
 
 		inFile := filepath.Join(inDir, tt.inFile)
 		inFileCSV := filepath.Join(csvDir, tt.inFileCSV)
-		if err := api.MultiFillFormFile(inFile, inFileCSV, outDir, inFile, true, conf); err != nil {
+		if err := api.MultiFillFormFile(inFile, inFileCSV, csvMergeDir, inFile, true, conf); err != nil {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 	}

--- a/pkg/api/test/grid_test.go
+++ b/pkg/api/test/grid_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +53,10 @@ func testGrid(t *testing.T, msg string, inFiles []string, outFile string, select
 
 func TestGrid(t *testing.T) {
 
-	outDir := filepath.Join(samplesDir, "grid")
+	gridDir := filepath.Join(outDir, "grid")
+	if err := os.MkdirAll(gridDir, os.ModePerm); err != nil {
+		t.Fatalf("TestGrid mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg           string
@@ -66,17 +70,17 @@ func TestGrid(t *testing.T) {
 	}{
 		{"TestGridFromPDF",
 			[]string{filepath.Join(inDir, "read.go.pdf")},
-			filepath.Join(outDir, "GridFromPDF.pdf"),
+			filepath.Join(gridDir, "GridFromPDF.pdf"),
 			nil, "form:LegalP, o:dr, border:off", "points", 4, 6, false},
 
 		{"TestGridFromPDFWithCropBox",
 			[]string{filepath.Join(inDir, "grid_example.pdf")},
-			filepath.Join(outDir, "GridFromPDFWithCropBox.pdf"),
+			filepath.Join(gridDir, "GridFromPDFWithCropBox.pdf"),
 			nil, "form:A5L, border:on, margin:0", "points", 2, 1, false},
 
 		{"TestGridFromImages",
 			imageFileNames(t, resDir),
-			filepath.Join(outDir, "GridFromImages.pdf"),
+			filepath.Join(gridDir, "GridFromImages.pdf"),
 			nil, "d:500 500, margin:20, bo:off", "points", 1, 4, true},
 	} {
 		conf := model.NewDefaultConfiguration()

--- a/pkg/api/test/images_test.go
+++ b/pkg/api/test/images_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,8 +37,11 @@ func testUpdateImages(t *testing.T, msg string, inFile, imgFile, outFile string,
 
 func TestUpdateImages(t *testing.T) {
 
-	outDir := filepath.Join(samplesDir, "images")
-	inDir := outDir
+	imgInDir := filepath.Join(samplesDir, "images")
+	imgOutDir := filepath.Join(outDir, "images")
+	if err := os.MkdirAll(imgOutDir, os.ModePerm); err != nil {
+		t.Fatalf("TestUpdateImages mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg     string
@@ -135,9 +139,9 @@ func TestUpdateImages(t *testing.T) {
 			"Im1"},
 	} {
 		testUpdateImages(t, tt.msg,
-			filepath.Join(inDir, tt.inFile),
-			filepath.Join(outDir, tt.imgFile),
-			filepath.Join(outDir, tt.outFile),
+			filepath.Join(imgInDir, tt.inFile),
+			filepath.Join(imgInDir, tt.imgFile),
+			filepath.Join(imgOutDir, tt.outFile),
 			tt.objNr,
 			tt.pageNr,
 			tt.id)

--- a/pkg/api/test/importImages_test.go
+++ b/pkg/api/test/importImages_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
 )
 
+// importDir returns a temporary output directory under the package-level outDir for import tests.
+func importDir(t *testing.T) string {
+	t.Helper()
+	d := filepath.Join(outDir, "import")
+	if err := os.MkdirAll(d, os.ModePerm); err != nil {
+		t.Fatalf("importDir mkdirAll: %v\n", err)
+	}
+	return d
+}
+
 func testImportImages(t *testing.T, msg string, imgFiles []string, outFile, impConf string) {
 	t.Helper()
 	var err error
@@ -51,12 +61,12 @@ func testImportImages(t *testing.T, msg string, imgFiles []string, outFile, impC
 
 func TestImportImages(t *testing.T) {
 
-	outDir := filepath.Join(samplesDir, "import")
+	impDir := importDir(t)
 
-	testFile1 := filepath.Join(outDir, "CenteredGraySepia.pdf")
+	testFile1 := filepath.Join(impDir, "CenteredGraySepia.pdf")
 	os.Remove(testFile1)
 
-	testFile2 := filepath.Join(outDir, "Full.pdf")
+	testFile2 := filepath.Join(impDir, "Full.pdf")
 	os.Remove(testFile2)
 
 	for _, tt := range []struct {

--- a/pkg/api/test/nup_test.go
+++ b/pkg/api/test/nup_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +53,10 @@ func testNUp(t *testing.T, msg string, inFiles []string, outFile string, selecte
 
 func TestNUp(t *testing.T) {
 
-	outDir := filepath.Join(samplesDir, "nup")
+	nupDir := filepath.Join(outDir, "nup")
+	if err := os.MkdirAll(nupDir, os.ModePerm); err != nil {
+		t.Fatalf("TestNUp mkdirAll: %v\n", err)
+	}
 
 	for _, tt := range []struct {
 		msg           string
@@ -67,7 +71,7 @@ func TestNUp(t *testing.T) {
 		// 4-Up a PDF
 		{"TestNUpFromPDF",
 			[]string{filepath.Join(inDir, "WaldenFull.pdf")},
-			filepath.Join(outDir, "NUpFromPDF.pdf"),
+			filepath.Join(nupDir, "NUpFromPDF.pdf"),
 			nil,
 			"dim: 400 800, margin:10, bgcol:#f7e6c7",
 			"mm",
@@ -77,7 +81,7 @@ func TestNUp(t *testing.T) {
 		// 2-Up a PDF with CropBox
 		{"TestNUpFromPdfWithCropBox",
 			[]string{filepath.Join(inDir, "grid_example.pdf")},
-			filepath.Join(outDir, "NUpFromPDFWithCropBox.pdf"),
+			filepath.Join(nupDir, "NUpFromPDFWithCropBox.pdf"),
 			nil,
 			"form:A5L, border:on, margin:0, bgcol:#f7e6c7",
 			"points",
@@ -87,7 +91,7 @@ func TestNUp(t *testing.T) {
 		// 16-Up an image
 		{"TestNUpFromSingleImage",
 			[]string{filepath.Join(resDir, "logoSmall.png")},
-			filepath.Join(outDir, "NUpFromSingleImage.pdf"),
+			filepath.Join(nupDir, "NUpFromSingleImage.pdf"),
 			nil,
 			"form:A3P, ma:10, bgcol:#f7e6c7",
 			"points",
@@ -97,7 +101,7 @@ func TestNUp(t *testing.T) {
 		// 6-Up a sequence of images.
 		{"TestNUpFromImages",
 			imageFileNames(t, resDir),
-			filepath.Join(outDir, "NUpFromImages.pdf"),
+			filepath.Join(nupDir, "NUpFromImages.pdf"),
 			nil,
 			"form:Tabloid, border:on, ma:10, bgcol:#f7e6c7",
 			"points",

--- a/pkg/api/test/resize_test.go
+++ b/pkg/api/test/resize_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +29,11 @@ import (
 func TestResizeByScaleFactor(t *testing.T) {
 	msg := "TestResizeByScaleFactor"
 
+	resizeDir := filepath.Join(outDir, "resize")
+	if err := os.MkdirAll(resizeDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	inFile := filepath.Join(inDir, "test.pdf")
 
 	// Enlarge by scale factor 2.
@@ -36,7 +42,7 @@ func TestResizeByScaleFactor(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile := filepath.Join(samplesDir, "resize", "enlargeByScaleFactor.pdf")
+	outFile := filepath.Join(resizeDir, "enlargeByScaleFactor.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -47,7 +53,7 @@ func TestResizeByScaleFactor(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile = filepath.Join(samplesDir, "resize", "shrinkByScaleFactor.pdf")
+	outFile = filepath.Join(resizeDir, "shrinkByScaleFactor.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -55,6 +61,11 @@ func TestResizeByScaleFactor(t *testing.T) {
 
 func TestResizeByWidthOrHeight(t *testing.T) {
 	msg := "TestResizeByWidthOrHeight"
+
+	resizeDir := filepath.Join(outDir, "resize")
+	if err := os.MkdirAll(resizeDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
 	inFile := filepath.Join(inDir, "test.pdf")
 
@@ -64,7 +75,7 @@ func TestResizeByWidthOrHeight(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile := filepath.Join(samplesDir, "resize", "resizeByWidth.pdf")
+	outFile := filepath.Join(resizeDir, "resizeByWidth.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -75,7 +86,7 @@ func TestResizeByWidthOrHeight(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile = filepath.Join(samplesDir, "resize", "resizeByHeight.pdf")
+	outFile = filepath.Join(resizeDir, "resizeByHeight.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -83,6 +94,11 @@ func TestResizeByWidthOrHeight(t *testing.T) {
 
 func TestResizeToFormSize(t *testing.T) {
 	msg := "TestResizeToPaperSize"
+
+	resizeDir := filepath.Join(outDir, "resize")
+	if err := os.MkdirAll(resizeDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
 	inFile := filepath.Join(inDir, "test.pdf")
 
@@ -92,7 +108,7 @@ func TestResizeToFormSize(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile := filepath.Join(samplesDir, "resize", "resizeToA3.pdf")
+	outFile := filepath.Join(resizeDir, "resizeToA3.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -103,7 +119,7 @@ func TestResizeToFormSize(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile = filepath.Join(samplesDir, "resize", "resizeToA4L.pdf")
+	outFile = filepath.Join(resizeDir, "resizeToA4L.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -111,6 +127,11 @@ func TestResizeToFormSize(t *testing.T) {
 
 func TestResizeToDimensions(t *testing.T) {
 	msg := "TestResizeToDimensions"
+
+	resizeDir := filepath.Join(outDir, "resize")
+	if err := os.MkdirAll(resizeDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
 	inFile := filepath.Join(inDir, "test.pdf")
 
@@ -121,7 +142,7 @@ func TestResizeToDimensions(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile := filepath.Join(samplesDir, "resize", "resizeToDimensionsKeep.pdf")
+	outFile := filepath.Join(resizeDir, "resizeToDimensionsKeep.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}
@@ -133,7 +154,7 @@ func TestResizeToDimensions(t *testing.T) {
 		t.Fatalf("%s invalid resize configuration: %v\n", msg, err)
 	}
 
-	outFile = filepath.Join(samplesDir, "resize", "resizeToDimensionsEnforce.pdf")
+	outFile = filepath.Join(resizeDir, "resizeToDimensionsEnforce.pdf")
 	if err := api.ResizeFile(inFile, outFile, nil, res, nil); err != nil {
 		t.Fatalf("%s resize: %v\n", msg, err)
 	}

--- a/pkg/api/test/stampUserFont_test.go
+++ b/pkg/api/test/stampUserFont_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,7 +28,10 @@ import (
 func TestStampUserFont(t *testing.T) {
 	msg := "TestStampUserFont"
 	inFile := filepath.Join(inDir, "mountain.pdf")
-	outDir := filepath.Join("..", "..", "samples", "stamp", "text", "utf8")
+	outDir := filepath.Join(outDir, "stamp", "text", "utf8")
+	if err := os.MkdirAll(outDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 
 	for _, sample := range langSamples {
 		outFile := filepath.Join(outDir, sample.lang+".pdf")

--- a/pkg/api/test/stampVersatile_test.go
+++ b/pkg/api/test/stampVersatile_test.go
@@ -31,8 +31,12 @@ import (
 
 func TestAlternatingPageNumbersViaWatermarkMap(t *testing.T) {
 	msg := "TestAlternatingPageNumbersViaWatermarkMap"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "WaldenFull.pdf")
-	outFile := filepath.Join(samplesDir, "stamp", "mixed", "AlternatingPageNumbersViaWatermarkMap.pdf")
+	outFile := filepath.Join(stampMixedDir, "AlternatingPageNumbersViaWatermarkMap.pdf")
 
 	pageCount, err := api.PageCountFile(inFile)
 	if err != nil {
@@ -85,8 +89,12 @@ func TestAlternatingPageNumbersViaWatermarkMap(t *testing.T) {
 
 func TestAlternatingPageNumbersViaWatermarkMapLowLevel(t *testing.T) {
 	msg := "TestAlternatingPageNumbersViaWatermarkMapLowLevel"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "WaldenFull.pdf")
-	outFile := filepath.Join(samplesDir, "stamp", "mixed", "AlternatingPageNumbersViaWatermarkMapLowLevel.pdf")
+	outFile := filepath.Join(stampMixedDir, "AlternatingPageNumbersViaWatermarkMapLowLevel.pdf")
 
 	// Create a context.
 	ctx, err := api.ReadContextFile(inFile)
@@ -151,8 +159,12 @@ func TestAlternatingPageNumbersViaWatermarkMapLowLevel(t *testing.T) {
 
 func TestAlternatingPageNumbersViaWatermarkSliceMap(t *testing.T) {
 	msg := "TestAlternatingPageNumbersViaWatermarkSliceMap"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "WaldenFull.pdf")
-	outFile := filepath.Join(samplesDir, "stamp", "mixed", "AlternatingPageNumbersViaWatermarkSliceMap.pdf")
+	outFile := filepath.Join(stampMixedDir, "AlternatingPageNumbersViaWatermarkSliceMap.pdf")
 
 	pageCount, err := api.PageCountFile(inFile)
 	if err != nil {
@@ -226,8 +238,12 @@ func TestAlternatingPageNumbersViaWatermarkSliceMap(t *testing.T) {
 
 func TestImagesTextAndPDFWMViaWatermarkMap(t *testing.T) {
 	msg := "TestImagesTextAndPDFWMViaWatermarkMap"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "WaldenFull.pdf")
-	outFile := filepath.Join(samplesDir, "stamp", "mixed", "ImagesTextAndPDFWMViaWatermarkMap.pdf")
+	outFile := filepath.Join(stampMixedDir, "ImagesTextAndPDFWMViaWatermarkMap.pdf")
 
 	pageCount, err := api.PageCountFile(inFile)
 	if err != nil {
@@ -282,6 +298,10 @@ func TestImagesTextAndPDFWMViaWatermarkMap(t *testing.T) {
 
 func TestPdfSingleStampVariations(t *testing.T) {
 	msg := "TestPdfSingleStampVariations"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "zineTest.pdf")
 	stampFile := inFile
 
@@ -319,7 +339,7 @@ func TestPdfSingleStampVariations(t *testing.T) {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 
-		outFile := filepath.Join(samplesDir, "stamp", "mixed", tt.outFile)
+		outFile := filepath.Join(stampMixedDir, tt.outFile)
 
 		if err = api.AddWatermarksFile(inFile, outFile, nil, wm, conf); err != nil {
 			t.Fatalf("%s %s: %v\n", tt.msg, outFile, err)
@@ -329,6 +349,10 @@ func TestPdfSingleStampVariations(t *testing.T) {
 
 func TestPdfMultiStampVariations(t *testing.T) {
 	msg := "TestPdfMultiStampVariations"
+	stampMixedDir := filepath.Join(outDir, "stamp", "mixed")
+	if err := os.MkdirAll(stampMixedDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
 	inFile := filepath.Join(inDir, "zineTest.pdf")
 	stampFile := inFile
 
@@ -383,7 +407,7 @@ func TestPdfMultiStampVariations(t *testing.T) {
 			t.Fatalf("%s: %v\n", tt.msg, err)
 		}
 
-		outFile := filepath.Join(samplesDir, "stamp", "mixed", tt.outFile)
+		outFile := filepath.Join(stampMixedDir, tt.outFile)
 
 		if err = api.AddWatermarksFile(inFile, outFile, nil, wm, conf); err != nil {
 			t.Fatalf("%s %s: %v\n", tt.msg, outFile, err)

--- a/pkg/api/test/stamp_test.go
+++ b/pkg/api/test/stamp_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +34,11 @@ func testAddWatermarks(t *testing.T, msg, inFile, outFile string, selectedPages 
 	if onTop {
 		s = "stamp"
 	}
-	outFile = filepath.Join(samplesDir, s, mode, outFile)
+	wmDir := filepath.Join(outDir, s, mode)
+	if err := os.MkdirAll(wmDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile = filepath.Join(wmDir, outFile)
 
 	var err error
 	switch mode {
@@ -502,7 +507,11 @@ func TestAddStampWithLink(t *testing.T) {
 func TestCropBox(t *testing.T) {
 	msg := "TestCropBox"
 	inFile := filepath.Join(inDir, "empty.pdf")
-	outFile := filepath.Join(samplesDir, "stamp", "pdf", "PdfWithCropBox.pdf")
+	stampPdfDir := filepath.Join(outDir, "stamp", "pdf")
+	if err := os.MkdirAll(stampPdfDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(stampPdfDir, "PdfWithCropBox.pdf")
 	pdfFile := filepath.Join(inDir, "grid_example.pdf")
 
 	// Create a context.
@@ -615,7 +624,11 @@ func TestStampingLifecycle(t *testing.T) {
 func TestRecycleWM(t *testing.T) {
 	msg := "TestRecycleWM"
 	inFile := filepath.Join(inDir, "test.pdf")
-	outFile := filepath.Join(samplesDir, "watermark", "text", "TextRecycled.pdf")
+	wmTextDir := filepath.Join(outDir, "watermark", "text")
+	if err := os.MkdirAll(wmTextDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+	outFile := filepath.Join(wmTextDir, "TextRecycled.pdf")
 	onTop := false // we are testing watermarks
 
 	desc := "pos:tl, points:22, rot:0, scale:1 abs, off:0 -5, opacity:0.3"

--- a/pkg/api/test/zoom_test.go
+++ b/pkg/api/test/zoom_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,13 +29,18 @@ import (
 func TestZoomInByFactor(t *testing.T) {
 	msg := "TestZoomInByFactor"
 
+	zoomDir := filepath.Join(outDir, "zoom")
+	if err := os.MkdirAll(zoomDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	inFile := filepath.Join(inDir, "test.pdf")
 
 	zoom, err := pdfcpu.ParseZoomConfig("factor:2", types.POINTS)
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile := filepath.Join(samplesDir, "zoom", "zoomInByFactor2.pdf")
+	outFile := filepath.Join(zoomDir, "zoomInByFactor2.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -43,7 +49,7 @@ func TestZoomInByFactor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile = filepath.Join(samplesDir, "zoom", "zoomInByFactor4.pdf")
+	outFile = filepath.Join(zoomDir, "zoomInByFactor4.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -52,13 +58,18 @@ func TestZoomInByFactor(t *testing.T) {
 func TestZoomOutByFactor(t *testing.T) {
 	msg := "TestZoomOutByFactor"
 
+	zoomDir := filepath.Join(outDir, "zoom")
+	if err := os.MkdirAll(zoomDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	inFile := filepath.Join(inDir, "test.pdf")
 
 	zoom, err := pdfcpu.ParseZoomConfig("factor:.5", types.POINTS)
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile := filepath.Join(samplesDir, "zoom", "zoomOutByFactor05.pdf")
+	outFile := filepath.Join(zoomDir, "zoomOutByFactor05.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -67,7 +78,7 @@ func TestZoomOutByFactor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile = filepath.Join(samplesDir, "zoom", "zoomOutByFactor025.pdf")
+	outFile = filepath.Join(zoomDir, "zoomOutByFactor025.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -76,13 +87,19 @@ func TestZoomOutByFactor(t *testing.T) {
 func TestZoomOutByHorizontalMargin(t *testing.T) {
 	// Zoom out of page content resulting in a preferred horizontal margin.
 	msg := "TestZoomOutByHMargin"
+
+	zoomDir := filepath.Join(outDir, "zoom")
+	if err := os.MkdirAll(zoomDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	inFile := filepath.Join(inDir, "test.pdf")
 
 	zoom, err := pdfcpu.ParseZoomConfig("hmargin:149", types.POINTS)
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile := filepath.Join(samplesDir, "zoom", "zoomOutByHMarginPoints.pdf")
+	outFile := filepath.Join(zoomDir, "zoomOutByHMarginPoints.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -91,7 +108,7 @@ func TestZoomOutByHorizontalMargin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile = filepath.Join(samplesDir, "zoom", "zoomOutByHMarginCm.pdf")
+	outFile = filepath.Join(zoomDir, "zoomOutByHMarginCm.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -100,13 +117,19 @@ func TestZoomOutByHorizontalMargin(t *testing.T) {
 func TestZoomOutByVerticalMargin(t *testing.T) {
 	// Zoom out of page content resulting in a preferred vertical margin.
 	msg := "TestZoomOutByVMargin"
+
+	zoomDir := filepath.Join(outDir, "zoom")
+	if err := os.MkdirAll(zoomDir, os.ModePerm); err != nil {
+		t.Fatalf("%s mkdirAll: %v\n", msg, err)
+	}
+
 	inFile := filepath.Join(inDir, "test.pdf")
 
 	zoom, err := pdfcpu.ParseZoomConfig("vmargin:1", types.INCHES)
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile := filepath.Join(samplesDir, "zoom", "zoomOutByVMarginInches.pdf")
+	outFile := filepath.Join(zoomDir, "zoomOutByVMarginInches.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}
@@ -115,7 +138,7 @@ func TestZoomOutByVerticalMargin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s invalid zoom configuration: %v\n", msg, err)
 	}
-	outFile = filepath.Join(samplesDir, "zoom", "zoomOutByVMarginMm.pdf")
+	outFile = filepath.Join(zoomDir, "zoomOutByVMarginMm.pdf")
 	if err := api.ZoomFile(inFile, outFile, nil, zoom, nil); err != nil {
 		t.Fatalf("%s zoom: %v\n", msg, err)
 	}

--- a/pkg/cli/test/bookmark_test.go
+++ b/pkg/cli/test/bookmark_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestListBookmarks(t *testing.T) {
 	msg := "TestListBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
+	inDir := filepath.Join(samplesDir, "bookmarks")
 	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
 
 	cmd := cli.ListBookmarksCommand(inFile, conf)
@@ -37,7 +37,7 @@ func TestListBookmarks(t *testing.T) {
 
 func TestExportBookmarks(t *testing.T) {
 	msg := "TestExportBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
+	inDir := filepath.Join(samplesDir, "bookmarks")
 	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
 	outFile := filepath.Join(outDir, "bookmarkTree.json")
 
@@ -49,7 +49,7 @@ func TestExportBookmarks(t *testing.T) {
 
 func TestImportBookmarks(t *testing.T) {
 	msg := "TestImportBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
+	inDir := filepath.Join(samplesDir, "bookmarks")
 	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
 	inFileJSON := filepath.Join(inDir, "bookmarkTree.json")
 	outFile := filepath.Join(outDir, "bookmarkTreeImported.pdf")
@@ -71,7 +71,7 @@ func TestImportBookmarks(t *testing.T) {
 
 func TestRemoveBookmarks(t *testing.T) {
 	msg := "TestRemoveBookmarks"
-	inDir := filepath.Join("..", "..", "samples", "bookmarks")
+	inDir := filepath.Join(samplesDir, "bookmarks")
 	inFile := filepath.Join(inDir, "bookmarkTree.pdf")
 	outFile := filepath.Join(outDir, "bookmarkTreeNoBookmarks.pdf")
 

--- a/pkg/pdfcpu/image_test.go
+++ b/pkg/pdfcpu/image_test.go
@@ -54,6 +54,11 @@ func TestMain(m *testing.M) {
 
 	exitCode := m.Run()
 
+	if err = os.RemoveAll(outDir); err != nil {
+		fmt.Printf("%v", err)
+		os.Exit(1)
+	}
+
 	os.Exit(exitCode)
 }
 


### PR DESCRIPTION
## Summary

- Redirect all test **output writes** from the committed `pkg/samples/` directory to the existing isolated `outDir` (created via `os.MkdirTemp` in `TestMain`)
- Keep all **input reads** from `pkg/samples/` fixtures unchanged
- Add missing `os.RemoveAll(outDir)` cleanup in `pkg/pdfcpu/image_test.go`

## Problem

Tests write output PDFs directly into `pkg/samples/`, which is a committed directory. When tests run in parallel (the default for `go test`), concurrent read/write on the same files causes intermittent failures — especially on CI runners where slower I/O widens the race window:

- macOS: `input/output error`
- Windows: `The file could not be opened because it is empty`

## Changes

**20 test files modified** across 3 packages:

| Package | Files | Change |
|---------|-------|--------|
| `pkg/api/test/` | 18 files | Output paths redirected from `samplesDir` / hardcoded `../../samples/` to `outDir` subdirectories |
| `pkg/cli/test/` | 1 file | Hardcoded `../../samples/bookmarks` input paths replaced with `samplesDir` variable |
| `pkg/pdfcpu/` | 1 file | Added `os.RemoveAll(outDir)` cleanup in `TestMain` |

No test logic or assertions were changed — only output file paths.

## Test plan

- [x] `go test ./pkg/api/test/` — all tests pass
- [x] `go test ./pkg/cli/test/` — all tests pass
- [x] `go test ./pkg/pdfcpu/` — all tests pass
- [x] `go build ./...` — builds cleanly
- [x] After running tests, `git diff pkg/samples/` shows **zero modifications** (previously showed 65+ modified files)

Fixes #1311