### PR TITLE
fix: check for nil bbPDF in CalcBoundingBox to prevent panic

### DIFF
--- a/pkg/pdfcpu/model/watermark.go
+++ b/pkg/pdfcpu/model/watermark.go
@@ -247,6 +247,9 @@ func (wm *Watermark) CalcBoundingBox(pageNr int) {
 			i := wm.PdfResIndex(pageNr)
 			wm.bbPDF = wm.PdfRes[i].Bb
 		}
+		if wm.bbPDF == nil {
+			return
+		}
 		wm.Width = int(wm.bbPDF.Width())
 		wm.Height = int(wm.bbPDF.Height())
 		bb = wm.bbPDF.CroppedCopy(0)


### PR DESCRIPTION
Fixes #990

## Problem

`CalcBoundingBox` dereferences `wm.bbPDF` (lines 250-252) without checking for nil. For some PDFs, `PdfRes[...].Bb` can be nil, causing a nil pointer dereference panic during watermark generation:

```go
wm.bbPDF = wm.PdfRes[wm.PdfPageNrSrc].Bb  // can be nil
wm.Width = int(wm.bbPDF.Width())            // PANIC
```

## Fix

Add a nil check after setting `wm.bbPDF`. If nil, return early to avoid the dereference.