### PR TITLE
fix(nameTree): handle empty Kids after removeKid

### DIFF
--- a/pkg/pdfcpu/model/nameTree.go
+++ b/pkg/pdfcpu/model/nameTree.go
@@ -470,6 +470,14 @@ func (n *Node) removeKid(xRefTable *XRefTable, kid *Node, i int) (bool, error) {
 		n.Kids = append(n.Kids[:i], n.Kids[i+1:]...)
 	}
 
+	if len(n.Kids) == 0 {
+		// The removed kid was the last one. Signal the caller so it can
+		// drop this now-empty intermediary node (and doesn't read
+		// n.Kids[0].Kmin below, which used to panic with "index out of
+		// range [0] with length 0" on single-child name-tree nodes).
+		return true, nil
+	}
+
 	if len(n.Kids) == 1 {
 
 		// If a single kid remains we can merge it with its parent.


### PR DESCRIPTION
Fixes pdfcpu/pdfcpu#1381.

## Problem

`removeKid` trimmed `n.Kids` and then only handled the single-child merge case. When the removed kid was the last one in the slice (`len(n.Kids) == 0`), it fell through with `noKids=false`, so `removeFromKids` proceeded to `n.Kmin = n.Kids[0].Kmin` on an empty slice and panicked:

```
panic: runtime error: index out of range [0] with length 0
model.(*Node).removeFromKids nameTree.go:530
model.(*Node).Remove nameTree.go:547
pdfcpu.removeDest bookmark.go:483
pdfcpu.RemoveBookmarks bookmark.go:565
```

Reporter's real-world PDFs with single-child `Dests` name-tree nodes hit this reliably from `RemoveBookmarks`.

## Fix

Return `noKids=true` from `removeKid` when `len(n.Kids) == 0` so the caller drops the now-empty intermediary instead of reading `Kids[0]`.

## Test

`go test ./pkg/pdfcpu/model/...` passes locally. The issue author's reproducer (generated malformed PDF with a single-child Dests node) no longer panics under `RemoveBookmarks`.