### PR TITLE
fix: tolerate corrupted StructTree entries in relaxed validation mode

### DIFF
--- a/pkg/pdfcpu/validate/numberTree.go
+++ b/pkg/pdfcpu/validate/numberTree.go
@@ -105,6 +105,10 @@ func validateNumberTreeDictNumsEntry(xRefTable *model.XRefTable, d types.Dict, n
 
 			i, ok := o.(types.Integer)
 			if !ok {
+				if xRefTable.ValidationMode == model.ValidationRelaxed {
+					model.ShowDigestedSpecViolation(fmt.Sprintf("validateNumberTreeDictNumsEntry: corrupt key <%v> - skipping remaining entries", o))
+					return firstKey, lastKey, nil
+				}
 				return 0, 0, errors.Errorf("pdfcpu: validateNumberTreeDictNumsEntry: corrupt key <%v>\n", o)
 			}
 

--- a/pkg/pdfcpu/validate/structTree.go
+++ b/pkg/pdfcpu/validate/structTree.go
@@ -526,6 +526,10 @@ func validateStructTreeRootDictEntryKArray(xRefTable *model.XRefTable, a types.A
 			return errors.Errorf("pdfcpu: validateStructTreeRootDictEntryKArray: invalid dictType %s (should be \"StructElem\")\n", *dictType)
 
 		default:
+			if xRefTable.ValidationMode == model.ValidationRelaxed {
+				model.ShowDigestedSpecViolation("validateStructTreeRootDictEntryKArray: unexpected struct tree value type")
+				continue
+			}
 			return errors.New("pdfcpu: validateStructTreeRootDictEntryKArray: unsupported PDF object")
 
 		}
@@ -568,6 +572,10 @@ func validateStructTreeRootDictEntryK(xRefTable *model.XRefTable, o types.Object
 		}
 
 	default:
+		if xRefTable.ValidationMode == model.ValidationRelaxed {
+			model.ShowDigestedSpecViolation("validateStructTreeRootDictEntryK: unexpected struct tree value type")
+			return nil
+		}
 		return errors.New("pdfcpu: validateStructTreeRootDictEntryK: unsupported PDF object")
 
 	}


### PR DESCRIPTION
Fixes #1385 - validation failures on PDFs where macOS Preview has corrupted the structure tree during page deletion.

## Problem

PDFs edited with macOS Preview (page deletion) can end up with a broken `StructTreeRoot`. The `ParentTree` number tree is left with invalid `Nums` entries - plain integers, empty arrays, and other non-dict objects appear where indirect references to struct element dicts are expected.

Two validation functions lacked the relaxed-mode guards present elsewhere in the codebase, causing hard errors even when `ValidationMode == ValidationRelaxed` (the default):

- `validateStructTreeRootDictEntryK`
- `validateStructTreeRootDictEntryKArray`

Additionally, `validateNumberTreeDictNumsEntry` did not handle non-integer keys (e.g. empty arrays `[]`) gracefully in relaxed mode.

## Changes

**`pkg/pdfcpu/validate/structTree.go`**

- `validateStructTreeRootDictEntryKArray`: added `default` case that logs a digested spec violation and `continue`s in relaxed mode instead of returning an error.
- `validateStructTreeRootDictEntryK`: added `default` case that logs a digested spec violation and returns `nil` in relaxed mode instead of returning an error.

**`pkg/pdfcpu/validate/numberTree.go`**

- `validateNumberTreeDictNumsEntry`: when a key at an even index is not a `types.Integer`, relaxed mode now logs a digested spec violation and returns early (skipping remaining entries) instead of returning an error.

## Behavior

- **Strict mode**: unchanged, all three paths still return errors on unexpected types.
- **Relaxed mode** (default): corrupted struct tree entries are skipped with a logged `digested:` message; the operation continues normally.

## Testing

Verified against a PDF produced by PowerPoint → macOS Preview page deletion that previously failed at `validateStructTreeRootDictEntryK`. After this fix, `pdfcpu validate`, `pdfcpu stamp`, and `pdfcpu watermark` all complete successfully on the same file.
