### PR TITLE
fix(stamp): check dereferenced dict for nil in DetectWatermarks and detectStampOCG

### DIFF
--- a/pkg/pdfcpu/stamp.go
+++ b/pkg/pdfcpu/stamp.go
@@ -1881,7 +1881,7 @@ func detectStampOCG(ctx *model.Context, arr types.Array) error {
 			return err
 		}
 
-		if o == nil {
+		if d == nil {
 			continue
 		}
 
@@ -2104,7 +2104,7 @@ func DetectWatermarks(ctx *model.Context) error {
 			return err
 		}
 
-		if o == nil {
+		if d == nil {
 			continue
 		}
 


### PR DESCRIPTION
## Summary

`DereferenceDict` can return a `nil` dict without an error when an OCG entry resolves to a null or freed object in the xref table. In both `DetectWatermarks` and `detectStampOCG`, the nil guard checked the input object `o` rather than the dereferenced result `d`:

```go
d, err := ctx.DereferenceDict(o)
if o == nil {   // wrong: o is never nil here, it came from the OCG array
    continue
}
if *d.Type() != "OCG" {  // panic: d is nil → d.Type() returns nil → *nil
```

**Fix:** check `d == nil` instead of `o == nil`.

## Reproduction

Calling `api.PDFInfo` on a PDF that has an `OCProperties` entry with a null/freed OCG object entry causes a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/pdfcpu/pdfcpu/pkg/pdfcpu.DetectWatermarks
    stamp.go:2153
github.com/pdfcpu/pdfcpu/pkg/api.PDFInfo
    info.go:56
```

## Changes

- `detectStampOCG` (line ~1884): `if o == nil` → `if d == nil`
- `DetectWatermarks` (line ~2107): `if o == nil` → `if d == nil`

Sample PDF: 
[Exmoor Properties PF LP 2024.pdf](https://github.com/user-attachments/files/27694222/Exmoor.Properties.PF.LP.2024.pdf)
