### PR TITLE
fix(merge): flatten /Pages tree to bound depth across multiple merges

### DIFF
--- a/pkg/api/test/merge_flat_tree_test.go
+++ b/pkg/api/test/merge_flat_tree_test.go
@@ -189,3 +189,208 @@ func TestMergeProducesFlatPageTree_WithDivider(t *testing.T) {
 	t.Logf("%s: merged %d inputs with divider → depth %d (max %d)",
 		msg, numInputs, depth, maxAcceptableDepth)
 }
+
+// rectsEqual handles nil-safe comparison of two *types.Rectangle.
+func rectsEqual(a, b *types.Rectangle) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return a.Equals(*b)
+	}
+}
+
+// TestMergePreservesInheritedPageAttrs guards the inherited-attribute
+// contract from the page-tree-fix. After merge, each output page must
+// resolve the SAME inherited attributes (/MediaBox, /CropBox, /Rotate,
+// /Resources) as its source page did pre-merge.
+//
+// Fixture choice: BuildingWebappsWithGo.pdf declares /MediaBox at the
+// source root /Pages and omits it from the leaf /Page dicts, so the
+// inheritance walk is genuinely exercised. If the fix ever regressed
+// to flatten source_root (dropping its attrs), this test would fail
+// because the leaf /Page dicts would lose /MediaBox.
+//
+// The test also asserts ctxDest.PageCount and the merged /Pages
+// /Count agree with N*srcPages — the count-bookkeeping half of the
+// maintainer's review ask.
+func TestMergePreservesInheritedPageAttrs(t *testing.T) {
+	const numInputs = 3
+
+	msg := "TestMergePreservesInheritedPageAttrs"
+	inFile := filepath.Join(inDir, "BuildingWebappsWithGo.pdf")
+
+	srcCtx, err := api.ReadContextFile(inFile)
+	if err != nil {
+		t.Fatalf("%s: ReadContextFile(src): %v", msg, err)
+	}
+
+	expected := make([]*model.InheritedPageAttrs, srcCtx.PageCount+1)
+	for pageNr := 1; pageNr <= srcCtx.PageCount; pageNr++ {
+		_, _, attrs, err := srcCtx.XRefTable.PageDict(pageNr, false)
+		if err != nil {
+			t.Fatalf("%s: src.PageDict(%d): %v", msg, pageNr, err)
+		}
+		expected[pageNr] = attrs
+	}
+
+	// Sanity: the fixture is supposed to inherit /MediaBox from its root
+	// /Pages. If that ever changes the test becomes vacuous — fail loudly
+	// rather than silently passing.
+	if expected[1].MediaBox == nil {
+		t.Fatalf("%s: fixture %s no longer inherits /MediaBox — pick another", msg, inFile)
+	}
+
+	inFiles := make([]string, numInputs)
+	for i := range inFiles {
+		inFiles[i] = inFile
+	}
+	outFile := filepath.Join(outDir, "merge_inherited_attrs.pdf")
+	if err := api.MergeCreateFile(inFiles, outFile, false, nil); err != nil {
+		t.Fatalf("%s: MergeCreateFile: %v", msg, err)
+	}
+	if err := api.ValidateFile(outFile, conf); err != nil {
+		t.Fatalf("%s: ValidateFile: %v", msg, err)
+	}
+
+	mergedCtx, err := api.ReadContextFile(outFile)
+	if err != nil {
+		t.Fatalf("%s: ReadContextFile(merged): %v", msg, err)
+	}
+
+	wantPages := numInputs * srcCtx.PageCount
+	if mergedCtx.PageCount != wantPages {
+		t.Fatalf("%s: merged PageCount = %d, want %d", msg, mergedCtx.PageCount, wantPages)
+	}
+
+	for pageNr := 1; pageNr <= mergedCtx.PageCount; pageNr++ {
+		_, _, got, err := mergedCtx.XRefTable.PageDict(pageNr, false)
+		if err != nil {
+			t.Fatalf("%s: merged.PageDict(%d): %v", msg, pageNr, err)
+		}
+		srcPageIdx := ((pageNr - 1) % srcCtx.PageCount) + 1
+		want := expected[srcPageIdx]
+
+		if !rectsEqual(want.MediaBox, got.MediaBox) {
+			t.Errorf("%s: page %d (src %d): MediaBox = %v, want %v",
+				msg, pageNr, srcPageIdx, got.MediaBox, want.MediaBox)
+		}
+		if !rectsEqual(want.CropBox, got.CropBox) {
+			t.Errorf("%s: page %d (src %d): CropBox = %v, want %v",
+				msg, pageNr, srcPageIdx, got.CropBox, want.CropBox)
+		}
+		if got.Rotate != want.Rotate {
+			t.Errorf("%s: page %d (src %d): Rotate = %d, want %d",
+				msg, pageNr, srcPageIdx, got.Rotate, want.Rotate)
+		}
+
+		// Resources: shallow top-level key check. Deep equality would be
+		// brittle (pdfcpu may re-emit refs differently); presence of every
+		// source key in the merged resolution is what proves the inherited
+		// Resources dict is still reachable.
+		switch {
+		case want.Resources == nil && got.Resources != nil:
+			t.Errorf("%s: page %d (src %d): Resources appeared post-merge", msg, pageNr, srcPageIdx)
+		case want.Resources != nil && got.Resources == nil:
+			t.Errorf("%s: page %d (src %d): Resources lost post-merge", msg, pageNr, srcPageIdx)
+		case want.Resources != nil && got.Resources != nil:
+			for k := range want.Resources {
+				if _, ok := got.Resources[k]; !ok {
+					t.Errorf("%s: page %d (src %d): Resources missing key %q",
+						msg, pageNr, srcPageIdx, k)
+				}
+			}
+		}
+	}
+
+	t.Logf("%s: merged %d × %d pages, inherited attrs preserved on all %d pages",
+		msg, numInputs, srcCtx.PageCount, wantPages)
+}
+
+// TestMergePageTreeParentLinks verifies the /Parent chain on the merged
+// output. Every leaf /Page must walk upward via /Parent and terminate
+// at the catalog's /Pages root — no broken links, no chain that loops
+// or detours through an orphan node.
+//
+// This is the structural half of the maintainer's "update parent
+// links/counts correctly" ask. The depth test catches degenerate
+// shape; this catches a broken-pointer regression that would leave
+// pdfcpu unable to walk back up the tree even though the file
+// validates.
+func TestMergePageTreeParentLinks(t *testing.T) {
+	const numInputs = 5
+
+	msg := "TestMergePageTreeParentLinks"
+	inFile := filepath.Join(inDir, "Acroforms2.pdf")
+
+	inFiles := make([]string, numInputs)
+	for i := range inFiles {
+		inFiles[i] = inFile
+	}
+	outFile := filepath.Join(outDir, "merge_parent_links.pdf")
+	if err := api.MergeCreateFile(inFiles, outFile, false, nil); err != nil {
+		t.Fatalf("%s: MergeCreateFile: %v", msg, err)
+	}
+
+	ctx, err := api.ReadContextFile(outFile)
+	if err != nil {
+		t.Fatalf("%s: ReadContextFile: %v", msg, err)
+	}
+
+	rootRef, err := ctx.Pages()
+	if err != nil {
+		t.Fatalf("%s: ctx.Pages: %v", msg, err)
+	}
+
+	// Catalog /Pages root itself must have no /Parent.
+	rootDict, err := ctx.XRefTable.DereferenceDict(*rootRef)
+	if err != nil {
+		t.Fatalf("%s: DereferenceDict(root): %v", msg, err)
+	}
+	if _, hasParent := rootDict["Parent"]; hasParent {
+		t.Errorf("%s: catalog /Pages root obj#%d has unexpected /Parent",
+			msg, rootRef.ObjectNumber)
+	}
+
+	const walkLimit = 50
+	for pageNr := 1; pageNr <= ctx.PageCount; pageNr++ {
+		leafRef, err := ctx.XRefTable.PageDictIndRef(pageNr)
+		if err != nil {
+			t.Fatalf("%s: PageDictIndRef(%d): %v", msg, pageNr, err)
+		}
+
+		cur := *leafRef
+		terminated := false
+		for step := 0; step <= walkLimit; step++ {
+			d, err := ctx.XRefTable.DereferenceDict(cur)
+			if err != nil {
+				t.Fatalf("%s: page %d: DereferenceDict(obj#%d): %v",
+					msg, pageNr, cur.ObjectNumber, err)
+			}
+			parentObj, hasParent := d["Parent"]
+			if !hasParent {
+				if cur.ObjectNumber != rootRef.ObjectNumber {
+					t.Errorf("%s: page %d: chain terminated at obj#%d, expected catalog /Pages obj#%d",
+						msg, pageNr, cur.ObjectNumber, rootRef.ObjectNumber)
+				}
+				terminated = true
+				break
+			}
+			parentRef, ok := parentObj.(types.IndirectRef)
+			if !ok {
+				t.Fatalf("%s: page %d: /Parent on obj#%d is not an indirect ref: %T",
+					msg, pageNr, cur.ObjectNumber, parentObj)
+			}
+			cur = parentRef
+		}
+		if !terminated {
+			t.Fatalf("%s: page %d: /Parent chain did not terminate within %d steps",
+				msg, pageNr, walkLimit)
+		}
+	}
+
+	t.Logf("%s: %d pages × parent chains all terminate at catalog /Pages obj#%d",
+		msg, ctx.PageCount, rootRef.ObjectNumber)
+}

--- a/pkg/api/test/merge_flat_tree_test.go
+++ b/pkg/api/test/merge_flat_tree_test.go
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Regression test for the degenerate-page-tree merge bug.
+// Tests for the merge page-tree shape and inheritance contract.
 //
-// Before the page-tree-fix patch, appendSourcePageTreeToDestPageTree
-// wrapped both the existing dest tree AND the source tree in a NEW
-// /Pages node on every merge call, producing a left-skewed binary
-// tree of depth N+1 for N inputs. Recursive PDF parsers (qpdf,
-// Adobe Acrobat) overflow their stack on trees deeper than a few
-// thousand levels. A real-world witness-pack merge of 2,404 single-
-// page inputs produced a 2,405-deep tree that crashed qpdf with
-// stack overflow and would not open in Acrobat.
+// MergeCreate/Append calls appendSourcePageTreeToDestPageTree per
+// input. These tests assert three invariants of that function:
 //
-// The fix splices source root /Pages into dest root's /Kids array
-// without wrapping. This test merges N inputs and asserts the
-// resulting page tree depth stays small.
+//   1. Depth at dest is bounded — does not grow with the number of
+//      inputs. Recursive consumers (qpdf, Adobe Acrobat) walk the
+//      page tree with a bounded stack and fail on deep trees.
+//   2. Inherited page attributes (/Resources, /MediaBox, /CropBox,
+//      /Rotate) declared on a source's root /Pages still resolve
+//      correctly at each merged leaf page.
+//   3. Every leaf's /Parent chain terminates at the catalog's /Pages
+//      root with no broken links.
 
 package test
 
@@ -85,18 +84,16 @@ func pageTreeDepth(t *testing.T, ctx *model.Context, indRef types.IndirectRef, c
 
 func TestMergeProducesFlatPageTree(t *testing.T) {
 	const (
-		// 100 inputs is enough to reliably catch the bug: pre-fix this
-		// would produce a 101-deep tree. We don't need to go to the
-		// thousands here — the bug is linear in N, so 100 is plenty
-		// of signal while keeping the test fast.
+		// 100 inputs gives a clear signal — a depth-bound regression
+		// would be linear in N, so 100 is enough to detect without
+		// scaling up further.
 		numInputs = 100
 
-		// Max acceptable depth: 1 (dest root /Pages) + source's own
-		// depth (typically 2: /Pages → /Page for stock test PDFs) =
-		// 3 in the typical case. Buffer to 10 to absorb test PDFs
-		// with slightly nested page trees of their own without flag-
-		// ging false positives. Anything close to numInputs means
-		// the wrap-on-every-merge bug regressed.
+		// Expected: 1 (dest root /Pages) + source's own depth
+		// (typically 2: /Pages → /Page) = 3 in the typical case.
+		// Buffered to 10 to absorb test PDFs with slightly nested
+		// page trees without false positives. Anything approaching
+		// numInputs indicates a depth-bound regression.
 		maxAcceptableDepth = 10
 	)
 
@@ -141,10 +138,8 @@ func TestMergeProducesFlatPageTree(t *testing.T) {
 }
 
 func TestMergeProducesFlatPageTree_WithDivider(t *testing.T) {
-	// Same as above but with dividerPage = true. The original code
-	// wrapped dest + divider + source in the new wrapper; the fix
-	// appends the divider directly to dest root's /Kids. Result
-	// should still be flat.
+	// Same as above with dividerPage = true — divider is appended
+	// directly to dest root's /Kids. Result should still be flat.
 
 	const (
 		numInputs          = 20
@@ -202,20 +197,17 @@ func rectsEqual(a, b *types.Rectangle) bool {
 	}
 }
 
-// TestMergePreservesInheritedPageAttrs guards the inherited-attribute
-// contract from the page-tree-fix. After merge, each output page must
-// resolve the SAME inherited attributes (/MediaBox, /CropBox, /Rotate,
-// /Resources) as its source page did pre-merge.
+// TestMergePreservesInheritedPageAttrs asserts that after merge each
+// output page resolves the same inherited attributes (/MediaBox,
+// /CropBox, /Rotate, /Resources) as its source page did pre-merge.
 //
-// Fixture choice: BuildingWebappsWithGo.pdf declares /MediaBox at the
-// source root /Pages and omits it from the leaf /Page dicts, so the
-// inheritance walk is genuinely exercised. If the fix ever regressed
-// to flatten source_root (dropping its attrs), this test would fail
-// because the leaf /Page dicts would lose /MediaBox.
+// Fixture: BuildingWebappsWithGo.pdf declares /MediaBox at the source
+// root /Pages and omits it from leaf /Page dicts, so the inheritance
+// walk is genuinely exercised. A regression that flattened source_root
+// (dropping its inheritable attrs) would cause leaf /Page dicts to
+// lose /MediaBox post-merge and this test would fail.
 //
-// The test also asserts ctxDest.PageCount and the merged /Pages
-// /Count agree with N*srcPages — the count-bookkeeping half of the
-// maintainer's review ask.
+// Also asserts ctxDest.PageCount equals N * srcPages.
 func TestMergePreservesInheritedPageAttrs(t *testing.T) {
 	const numInputs = 3
 
@@ -314,11 +306,9 @@ func TestMergePreservesInheritedPageAttrs(t *testing.T) {
 // at the catalog's /Pages root — no broken links, no chain that loops
 // or detours through an orphan node.
 //
-// This is the structural half of the maintainer's "update parent
-// links/counts correctly" ask. The depth test catches degenerate
-// shape; this catches a broken-pointer regression that would leave
-// pdfcpu unable to walk back up the tree even though the file
-// validates.
+// The depth test catches degenerate shape; this catches a broken-
+// pointer regression that would leave pdfcpu unable to walk back up
+// the tree even though the file validates.
 func TestMergePageTreeParentLinks(t *testing.T) {
 	const numInputs = 5
 

--- a/pkg/api/test/merge_flat_tree_test.go
+++ b/pkg/api/test/merge_flat_tree_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 The pdfcpu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Regression test for the degenerate-page-tree merge bug.
+//
+// Before the page-tree-fix patch, appendSourcePageTreeToDestPageTree
+// wrapped both the existing dest tree AND the source tree in a NEW
+// /Pages node on every merge call, producing a left-skewed binary
+// tree of depth N+1 for N inputs. Recursive PDF parsers (qpdf,
+// Adobe Acrobat) overflow their stack on trees deeper than a few
+// thousand levels. A real-world witness-pack merge of 2,404 single-
+// page inputs produced a 2,405-deep tree that crashed qpdf with
+// stack overflow and would not open in Acrobat.
+//
+// The fix splices source root /Pages into dest root's /Kids array
+// without wrapping. This test merges N inputs and asserts the
+// resulting page tree depth stays small.
+
+package test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/types"
+)
+
+// pageTreeDepth recursively measures the maximum depth of a /Pages
+// subtree rooted at indRef. Bails at sanityLimit to avoid hitting
+// the test runner's stack overflow — if we hit that, the test fails
+// with a clear "degenerate tree" message rather than a confusing
+// runtime panic.
+func pageTreeDepth(t *testing.T, ctx *model.Context, indRef types.IndirectRef, currentDepth int) int {
+	t.Helper()
+
+	const sanityLimit = 5000
+	if currentDepth > sanityLimit {
+		t.Fatalf("page tree walk exceeded sanity limit %d — tree is degenerate", sanityLimit)
+	}
+
+	d, err := ctx.XRefTable.DereferenceDict(indRef)
+	if err != nil {
+		t.Fatalf("DereferenceDict(%v): %v", indRef, err)
+	}
+
+	// /Page leaf: depth is currentDepth + 1 (counting this node).
+	if typ := d.Type(); typ != nil && *typ == "Page" {
+		return currentDepth + 1
+	}
+
+	kids, ok := d["Kids"].(types.Array)
+	if !ok || len(kids) == 0 {
+		return currentDepth + 1
+	}
+
+	// /Pages node — recurse into kids, return the max depth.
+	maxDepth := currentDepth + 1
+	for _, kid := range kids {
+		kidRef, ok := kid.(types.IndirectRef)
+		if !ok {
+			continue
+		}
+		kidDepth := pageTreeDepth(t, ctx, kidRef, currentDepth+1)
+		if kidDepth > maxDepth {
+			maxDepth = kidDepth
+		}
+	}
+	return maxDepth
+}
+
+func TestMergeProducesFlatPageTree(t *testing.T) {
+	const (
+		// 100 inputs is enough to reliably catch the bug: pre-fix this
+		// would produce a 101-deep tree. We don't need to go to the
+		// thousands here — the bug is linear in N, so 100 is plenty
+		// of signal while keeping the test fast.
+		numInputs = 100
+
+		// Max acceptable depth: 1 (dest root /Pages) + source's own
+		// depth (typically 2: /Pages → /Page for stock test PDFs) =
+		// 3 in the typical case. Buffer to 10 to absorb test PDFs
+		// with slightly nested page trees of their own without flag-
+		// ging false positives. Anything close to numInputs means
+		// the wrap-on-every-merge bug regressed.
+		maxAcceptableDepth = 10
+	)
+
+	msg := "TestMergeProducesFlatPageTree"
+
+	inFile := filepath.Join(inDir, "Acroforms2.pdf")
+	inFiles := make([]string, numInputs)
+	for i := range inFiles {
+		inFiles[i] = inFile
+	}
+
+	outFile := filepath.Join(outDir, "merge_flat_tree.pdf")
+	if err := api.MergeCreateFile(inFiles, outFile, false, nil); err != nil {
+		t.Fatalf("%s: MergeCreateFile: %v", msg, err)
+	}
+
+	if err := api.ValidateFile(outFile, conf); err != nil {
+		t.Fatalf("%s: ValidateFile: %v", msg, err)
+	}
+
+	ctx, err := api.ReadContextFile(outFile)
+	if err != nil {
+		t.Fatalf("%s: ReadContextFile: %v", msg, err)
+	}
+
+	indRefRoot, err := ctx.Pages()
+	if err != nil {
+		t.Fatalf("%s: ctx.Pages: %v", msg, err)
+	}
+
+	depth := pageTreeDepth(t, ctx, *indRefRoot, 0)
+
+	if depth > maxAcceptableDepth {
+		t.Fatalf(
+			"%s: page tree depth %d exceeds maximum %d after merging %d inputs — "+
+				"degenerate-tree regression (see appendSourcePageTreeToDestPageTree)",
+			msg, depth, maxAcceptableDepth, numInputs,
+		)
+	}
+	t.Logf("%s: merged %d inputs → page tree depth %d (well within max %d)",
+		msg, numInputs, depth, maxAcceptableDepth)
+}
+
+func TestMergeProducesFlatPageTree_WithDivider(t *testing.T) {
+	// Same as above but with dividerPage = true. The original code
+	// wrapped dest + divider + source in the new wrapper; the fix
+	// appends the divider directly to dest root's /Kids. Result
+	// should still be flat.
+
+	const (
+		numInputs          = 20
+		maxAcceptableDepth = 10
+	)
+
+	msg := "TestMergeProducesFlatPageTree_WithDivider"
+
+	inFile := filepath.Join(inDir, "Acroforms2.pdf")
+	inFiles := make([]string, numInputs)
+	for i := range inFiles {
+		inFiles[i] = inFile
+	}
+
+	outFile := filepath.Join(outDir, "merge_flat_tree_with_divider.pdf")
+	if err := api.MergeCreateFile(inFiles, outFile, true, nil); err != nil {
+		t.Fatalf("%s: MergeCreateFile: %v", msg, err)
+	}
+
+	if err := api.ValidateFile(outFile, conf); err != nil {
+		t.Fatalf("%s: ValidateFile: %v", msg, err)
+	}
+
+	ctx, err := api.ReadContextFile(outFile)
+	if err != nil {
+		t.Fatalf("%s: ReadContextFile: %v", msg, err)
+	}
+
+	indRefRoot, err := ctx.Pages()
+	if err != nil {
+		t.Fatalf("%s: ctx.Pages: %v", msg, err)
+	}
+
+	depth := pageTreeDepth(t, ctx, *indRefRoot, 0)
+
+	if depth > maxAcceptableDepth {
+		t.Fatalf(
+			"%s: page tree depth %d exceeds maximum %d (divider-page path regressed)",
+			msg, depth, maxAcceptableDepth,
+		)
+	}
+	t.Logf("%s: merged %d inputs with divider → depth %d (max %d)",
+		msg, numInputs, depth, maxAcceptableDepth)
+}

--- a/pkg/pdfcpu/merge.go
+++ b/pkg/pdfcpu/merge.go
@@ -914,6 +914,39 @@ func createDividerPagesDict(ctx *model.Context, parentIndRef types.IndirectRef) 
 	return indRef, nil
 }
 
+// appendSourcePageTreeToDestPageTree splices the source PDF's root /Pages
+// node into the destination's root /Pages /Kids array, producing a flat
+// (shallow-but-wide) tree shape.
+//
+// FIX FOR DEGENERATE PAGE TREE (page-tree-fix fork branch, v0.11.1):
+//
+// The original implementation wrapped both the existing dest tree AND
+// the source tree in a NEW /Pages node on every merge call, then pointed
+// the catalog at that new wrapper:
+//
+//	new_wrapper
+//	  Kids: [old_dest_root, source_root]
+//
+// After N merge calls, this produces a left-skewed binary tree of
+// depth N+1. Recursive PDF parsers (qpdf, Adobe Acrobat) overflow
+// their stack when walking trees deeper than a few thousand levels.
+// Empirically: a witness-pack merge of 2,404 single-page inputs
+// produced a 2,405-deep tree that crashed qpdf with stack overflow
+// and would not open in Acrobat Reader.
+//
+// FIX: Keep dest's root /Pages node unchanged across merges. Reparent
+// the source's root /Pages to be a child of dest root, and append it
+// to dest_root.Kids. After N merges, dest_root.Kids has N entries
+// (plus dividers if requested) — a wide-but-shallow tree.
+//
+// Source root's own subtree is preserved as-is. This means:
+//
+//  1. Any inheritable attributes set on the source root (/Resources,
+//     /MediaBox, /CropBox, /Rotate) propagate correctly to its
+//     descendant pages — same semantics as the original wrapper.
+//  2. Source PDFs with their own deep page trees still come through
+//     correctly. Tree depth at dest is bounded by max(source depth) + 1,
+//     not N.
 func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerPage bool) error {
 	if log.DebugEnabled() {
 		log.Debug.Println("appendSourcePageTreeToDestPageTree begin")
@@ -934,57 +967,62 @@ func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerP
 		return errors.Errorf("pdfcpu: corrupt page node at obj #%d\n", indRefPageTreeRootDictDest.ObjectNumber)
 	}
 
-	c := ctxDest.PageCount
-
-	d := types.NewDict()
-	d.InsertName("Type", "Pages")
-	kids := types.Array{*indRefPageTreeRootDictDest}
-
-	indRef, err := ctxDest.IndRefForNewObject(d)
-	if err != nil {
-		return err
+	// Pull dest's existing /Kids array. We will append to this rather
+	// than wrap it in a new node.
+	destKidsObj, ok := pageTreeRootDictDest["Kids"]
+	if !ok {
+		return errors.Errorf("pdfcpu: dest /Pages obj #%d missing /Kids", indRefPageTreeRootDictDest.ObjectNumber)
+	}
+	destKids, ok := destKidsObj.(types.Array)
+	if !ok {
+		return errors.Errorf("pdfcpu: dest /Pages obj #%d /Kids is not an Array", indRefPageTreeRootDictDest.ObjectNumber)
 	}
 
+	addedPageCount := 0
+
+	// Optional divider page between previous content and this source.
+	// Same as the original implementation but parented to dest root
+	// rather than a new wrapper.
 	if dividerPage {
-		dividerPagesNodeIndRef, err := createDividerPagesDict(ctxDest, *indRef)
+		dividerPagesNodeIndRef, err := createDividerPagesDict(ctxDest, *indRefPageTreeRootDictDest)
 		if err != nil {
 			return err
 		}
-		kids = append(kids, *dividerPagesNodeIndRef)
-		c++
+		destKids = append(destKids, *dividerPagesNodeIndRef)
+		addedPageCount++
 	}
-
-	pageTreeRootDictDest["Parent"] = *indRef
 
 	indRefPageTreeRootDictSource, err := ctxSrc.Pages()
 	if err != nil {
 		return err
 	}
 
-	d.Insert("Kids", append(kids, *indRefPageTreeRootDictSource))
-
 	pageTreeRootDictSource, err := ctxSrc.XRefTable.DereferenceDict(*indRefPageTreeRootDictSource)
 	if err != nil {
 		return err
 	}
-
-	pageTreeRootDictSource["Parent"] = *indRef
 
 	pageCountSource := pageTreeRootDictSource.IntEntry("Count")
 	if pageCountSource == nil || *pageCountSource != ctxSrc.PageCount {
 		return errors.Errorf("pdfcpu: corrupt page node at obj #%d\n", indRefPageTreeRootDictSource.ObjectNumber)
 	}
 
-	c += ctxSrc.PageCount
-	d.InsertInt("Count", c)
-	ctxDest.PageCount = c
+	// Reparent source root to dest root. The original code parented BOTH
+	// source root and the previous dest root under a new wrapper; here
+	// only source root needs to update — dest root stays as the catalog's
+	// /Pages reference, so its lack of /Parent is correct.
+	pageTreeRootDictSource["Parent"] = *indRefPageTreeRootDictDest
 
-	rootDict, err := ctxDest.Catalog()
-	if err != nil {
-		return err
-	}
+	// Append source root as a kid of dest root — splice, not wrap.
+	destKids = append(destKids, *indRefPageTreeRootDictSource)
+	addedPageCount += ctxSrc.PageCount
 
-	rootDict["Pages"] = *indRef
+	// Persist the updated /Kids and /Count on dest's root /Pages.
+	pageTreeRootDictDest["Kids"] = destKids
+	pageTreeRootDictDest["Count"] = types.Integer(ctxDest.PageCount + addedPageCount)
+	ctxDest.PageCount += addedPageCount
+
+	// Catalog's /Pages reference stays pointed at dest root — unchanged.
 
 	if log.DebugEnabled() {
 		log.Debug.Println("appendSourcePageTreeToDestPageTree end")

--- a/pkg/pdfcpu/merge.go
+++ b/pkg/pdfcpu/merge.go
@@ -914,39 +914,19 @@ func createDividerPagesDict(ctx *model.Context, parentIndRef types.IndirectRef) 
 	return indRef, nil
 }
 
-// appendSourcePageTreeToDestPageTree splices the source PDF's root /Pages
-// node into the destination's root /Pages /Kids array, producing a flat
-// (shallow-but-wide) tree shape.
+// appendSourcePageTreeToDestPageTree appends the source PDF's root
+// /Pages node to the destination's root /Pages /Kids array.
 //
-// FIX FOR DEGENERATE PAGE TREE (page-tree-fix fork branch, v0.11.1):
+// dest_root is preserved across merge calls; each call adds a single
+// entry to dest_root.Kids (the source root, plus an optional divider
+// page). Resulting depth at dest is bounded by max(source depth) + 1,
+// independent of N.
 //
-// The original implementation wrapped both the existing dest tree AND
-// the source tree in a NEW /Pages node on every merge call, then pointed
-// the catalog at that new wrapper:
-//
-//	new_wrapper
-//	  Kids: [old_dest_root, source_root]
-//
-// After N merge calls, this produces a left-skewed binary tree of
-// depth N+1. Recursive PDF parsers (qpdf, Adobe Acrobat) overflow
-// their stack when walking trees deeper than a few thousand levels.
-// Empirically: a witness-pack merge of 2,404 single-page inputs
-// produced a 2,405-deep tree that crashed qpdf with stack overflow
-// and would not open in Acrobat Reader.
-//
-// FIX: Keep dest's root /Pages node unchanged across merges. Reparent
-// the source's root /Pages to be a child of dest root, and append it
-// to dest_root.Kids. After N merges, dest_root.Kids has N entries
-// (plus dividers if requested) — a wide-but-shallow tree.
-//
-// Source root's own subtree is preserved as-is. This means:
-//
-//  1. Any inheritable attributes set on the source root (/Resources,
-//     /MediaBox, /CropBox, /Rotate) propagate correctly to its
-//     descendant pages — same semantics as the original wrapper.
-//  2. Source PDFs with their own deep page trees still come through
-//     correctly. Tree depth at dest is bounded by max(source depth) + 1,
-//     not N.
+// Source root is kept intact as an inner /Pages node — only its
+// /Parent is updated to point at dest_root. This preserves any
+// inheritable attributes (/Resources, /MediaBox, /CropBox, /Rotate)
+// set on the source root: leaf pages still resolve them via the
+// normal inheritance walk because source_root remains in the chain.
 func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerPage bool) error {
 	if log.DebugEnabled() {
 		log.Debug.Println("appendSourcePageTreeToDestPageTree begin")
@@ -967,8 +947,6 @@ func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerP
 		return errors.Errorf("pdfcpu: corrupt page node at obj #%d\n", indRefPageTreeRootDictDest.ObjectNumber)
 	}
 
-	// Pull dest's existing /Kids array. We will append to this rather
-	// than wrap it in a new node.
 	destKidsObj, ok := pageTreeRootDictDest["Kids"]
 	if !ok {
 		return errors.Errorf("pdfcpu: dest /Pages obj #%d missing /Kids", indRefPageTreeRootDictDest.ObjectNumber)
@@ -981,8 +959,6 @@ func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerP
 	addedPageCount := 0
 
 	// Optional divider page between previous content and this source.
-	// Same as the original implementation but parented to dest root
-	// rather than a new wrapper.
 	if dividerPage {
 		dividerPagesNodeIndRef, err := createDividerPagesDict(ctxDest, *indRefPageTreeRootDictDest)
 		if err != nil {
@@ -1007,22 +983,16 @@ func appendSourcePageTreeToDestPageTree(ctxSrc, ctxDest *model.Context, dividerP
 		return errors.Errorf("pdfcpu: corrupt page node at obj #%d\n", indRefPageTreeRootDictSource.ObjectNumber)
 	}
 
-	// Reparent source root to dest root. The original code parented BOTH
-	// source root and the previous dest root under a new wrapper; here
-	// only source root needs to update — dest root stays as the catalog's
-	// /Pages reference, so its lack of /Parent is correct.
+	// Reparent source root to dest root. dest_root remains the catalog's
+	// /Pages reference and has no /Parent itself.
 	pageTreeRootDictSource["Parent"] = *indRefPageTreeRootDictDest
 
-	// Append source root as a kid of dest root — splice, not wrap.
 	destKids = append(destKids, *indRefPageTreeRootDictSource)
 	addedPageCount += ctxSrc.PageCount
 
-	// Persist the updated /Kids and /Count on dest's root /Pages.
 	pageTreeRootDictDest["Kids"] = destKids
 	pageTreeRootDictDest["Count"] = types.Integer(ctxDest.PageCount + addedPageCount)
 	ctxDest.PageCount += addedPageCount
-
-	// Catalog's /Pages reference stays pointed at dest root — unchanged.
 
 	if log.DebugEnabled() {
 		log.Debug.Println("appendSourcePageTreeToDestPageTree end")


### PR DESCRIPTION
Fixes #1404

Per discussion in the issue, here's the fix.

appendSourcePageTreeToDestPageTree previously wrapped both dest and
source roots in a new /Pages node every call, producing depth = N+1
after N merges. This rebases source root as a child of dest root and
appends to dest_root.Kids — depth at dest is now max(source depth) + 1.

Three regression tests under pkg/api/test:
- TestMergeProducesFlatPageTree[_WithDivider]: depth guard.
- TestMergePreservesInheritedPageAttrs: consolidated /MediaBox,
  /CropBox, /Rotate, /Resources at each merged page match the source.
- TestMergePageTreeParentLinks: every leaf's /Parent chain
  terminates at the catalog's /Pages root.

OS: Windows 10. Running this fork in production for legal-document
merges (typical batch 2,000+ inputs), no issues observed.

Heads-up: my fork's CI showed intermittent bookmark CLI test flakes
(TestImportBookmarks, TestRemoveBookmarks, TestAddDuplicateBookmarks)
in inconsistent patterns across platforms. They appear pre-existing
and unrelated — this patch only touches appendSourcePageTreeToDestPageTree,
which bookmark tests don't exercise. Local `go test ./...` against
upstream master is green. Upstream's CI on this PR should be
authoritative.