### PR TITLE
Use default configuration in ReadAndValidate when conf is nil

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -171,6 +171,10 @@ func WriteContextFile(ctx *model.Context, outFile string) error {
 func ReadAndValidate(rs io.ReadSeeker, conf *model.Configuration) (ctx *model.Context, err error) {
 	defer fault.Catch(&err)
 
+	if conf == nil {
+		conf = model.NewDefaultConfiguration()
+	}
+
 	if ctx, err = ReadContext(rs, conf); err != nil {
 		return nil, err
 	}

--- a/pkg/api/test/readandvalidate_nilconf_test.go
+++ b/pkg/api/test/readandvalidate_nilconf_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The pdfcpu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pdfcpu/pdfcpu/pkg/api"
+)
+
+func TestReadAndValidateNilConf(t *testing.T) {
+	msg := "TestReadAndValidateNilConf"
+
+	f, err := os.Open(filepath.Join(inDir, "gobook.0.pdf"))
+	if err != nil {
+		t.Fatalf("%s: %v\n", msg, err)
+	}
+	defer f.Close()
+
+	if _, err := api.ReadAndValidate(f, nil); err != nil {
+		t.Fatalf("%s: %v\n", msg, err)
+	}
+}


### PR DESCRIPTION
Fixes #1432

`ReadAndValidate` dereferences `conf.Cmd` at `pkg/api/api.go:182` but never guards against a `nil` conf. `ReadContext` tolerates a `nil` conf internally (through `pdfcpu.Read`), so the read and validate steps succeed, but the later `conf.Cmd` access panics.

Other entry points such as `ReadValidateAndOptimize` and the functions in `annotation.go` already fall back to `model.NewDefaultConfiguration()` when conf is nil. This applies the same fallback so `ReadAndValidate` behaves consistently.

Added a regression test that opens `gobook.0.pdf` and calls `api.ReadAndValidate(f, nil)`, which panics without the fix and passes with it.
