### PR TITLE
exclude pkg/samples and pkg/testdata from the module zip

### DIFF
--- a/pkg/samples/go.mod
+++ b/pkg/samples/go.mod
@@ -1,0 +1,5 @@
+// Nested module: keeps the sample corpus out of the parent module's zip.
+// See https://github.com/pdfcpu/pdfcpu/issues/1449 and golang/go#37724.
+module github.com/pdfcpu/pdfcpu/pkg/samples
+
+go 1.25.0

--- a/pkg/testdata/go.mod
+++ b/pkg/testdata/go.mod
@@ -1,0 +1,5 @@
+// Nested module: keeps test fixtures out of the parent module's zip.
+// See https://github.com/pdfcpu/pdfcpu/issues/1449 and golang/go#37724.
+module github.com/pdfcpu/pdfcpu/pkg/testdata
+
+go 1.25.0


### PR DESCRIPTION
Nested go.mod stubs mark both directories as separate modules, which the Go tooling excludes from the parent module zip (golang/go#37724).

Cuts the published zip from 265 MB to 15 MB. Files remain in git, so CI and checkout-based workflows are unchanged.

Fixes #1449 